### PR TITLE
Fix compatibility with Pug template inheritance

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -90,7 +90,7 @@ module.exports = async function (content, sourceMap) {
       if (component.template.lang === 'pug') {
         const pug = requirePeer('pug')
         try {
-          component.template.content = pug.render(component.template.content)
+          component.template.content = pug.render(component.template.content, {filename: this.resourcePath})
         } catch (err) {/* Ignore compilation errors, they'll be picked up by other loaders */}
       }
       compiler.compile(component.template.content, {


### PR DESCRIPTION
This PR add path information in addition with the template content to `pug.render`. This allows Pug's `extends` to work, rather than failing and being silently ignored.

A test example:

```vue
<template lang="pug">
    extends './partial.pug'
    block content
        v-btn Click Here
</template>
```

```pug
//- partial.pug
.container
    block content
```