### PR TITLE
Use webpack path resolution with template src path

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -83,7 +83,12 @@ module.exports = async function (content, sourceMap) {
     const component = compiler.parseComponent(file)
     if (component.template) {
       if (component.template.src) {
-        const externalFile = path.resolve(path.dirname(this.resourcePath), component.template.src);
+        const externalFile = (await new Promise((resolve, reject) =>
+          this.resolve(path.dirname(this.resourcePath), component.template.src, (err, result) => {
+            if (err) reject(err)
+            else resolve(result)
+          })
+        ))
         const externalContent = (await readFile(externalFile)).toString('utf8')
         component.template.content = externalContent
       }


### PR DESCRIPTION
Instead of always treating the external template src path as a relative path, use webpack path resolution instead.

Issue reference: #76