### PR TITLE
Fix Typo

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -37,7 +37,7 @@ function install (install, content, imports) {
     let newContent = '/* vuetify-loader */\n'
     newContent += `import ${install} from ${loaderUtils.stringifyRequest(this, '!' + runtimePaths[install])}\n`
     newContent += imports.map(i => i[1]).join('\n') + '\n'
-    newContent += `${install}(component, {${imports.map(i => i[0]).join(',')}})\n`
+    newContent += `${install}(Component, {${imports.map(i => i[0]).join(',')}})\n`
 
     // Insert our modification before the HMR code
     const hotReload = content.indexOf('/* hot reload */')


### PR DESCRIPTION
I've been trying to upgrade a project from vuetify 1.5 to 2.0. Following the documentation, I got webpack to use the vuetify-loader plugin. I was able to successfully run webpack. However, upon loading the page, I ran into this error.

![error_log](https://user-images.githubusercontent.com/32378821/62782827-080f0a00-ba89-11e9-8774-8985d5f3914f.png)

I clicked the top link in the stack trace and saw this.

![code](https://user-images.githubusercontent.com/32378821/62782902-2e34aa00-ba89-11e9-938c-3e9048f171b0.png)


I noticed that the "component" variable used as an argument on line 39 was undefined. It is not capitalized like the "Component" variable declared on on line 20. I forked this repo and found the code producing this statement. I capitalized the variable and now my application works. Unless there's another variable named "component" that I'm not aware of, I think it should be capitalized.

This pull request is a one letter change capitalizing that variable.