### PR TITLE
Package info fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vuetify-loader",
   "version": "1.4.1",
-  "description": "",
+  "description": "A Webpack plugin for treeshaking Vuetify components and more",
   "main": "lib/index.js",
   "repository": {
     "type": "git",
@@ -13,9 +13,9 @@
   "author": "",
   "license": "MIT",
   "bugs": {
-    "url": "git+https://github.com/vuetifyjs/vuetify-loader/issues"
+    "url": "https://github.com/vuetifyjs/vuetify-loader/issues"
   },
-  "homepage": "git+https://github.com/vuetifyjs/vuetify-loader#readme",
+  "homepage": "https://github.com/vuetifyjs/vuetify-loader#readme",
   "dependencies": {
     "loader-utils": "^1.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuetify-loader",
-  "version": "1.4.1",
+  "version": "1.4.3",
   "description": "A Webpack plugin for treeshaking Vuetify components and more",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
I hope this is enough to fix the issue I raised in [#108](https://github.com/vuetifyjs/vuetify-loader/issues/108).

This also bumps the version back to 1.4.3, which had been set back to 1.4.1 for some reason in the last commit. [e866b36](https://github.com/vuetifyjs/vuetify-loader/commit/e866b369999432314def9bd7f2d65579bb4a9d59)