### PR TITLE
feat: add option handleAllVueLoaders to handle all vue loaders. fix #106

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -22,16 +22,28 @@ class VuetifyLoaderPlugin {
     const { rules } = new RuleSet(rawRules)
 
     // find the rule that applies to vue files
-    const vueRuleIndex = rules.findIndex(rule => rule.use && rule.use.find(isVueLoader))
-    const vueRule = rules[vueRuleIndex]
+    const vueRules = rules.filter(rule => rule.use && rule.use.find(isVueLoader))
 
-    if (!vueRule) {
+    if (vueRules.length === 0) {
       throw new Error(
         `[VuetifyLoaderPlugin Error] No matching rule for vue-loader found.\n` +
         `Make sure there is at least one root-level rule that uses vue-loader.`
       )
     }
 
+    if (this.options.handleAllVueLoaders) {
+      for (const vueRule of vueRules) {
+        this.applyForVueRule(vueRule)
+      }
+    } else {
+      const vueRule = vueRules[0]
+      this.applyForVueRule(vueRule)
+    }
+
+    compiler.options.module.rules = rules
+  }
+
+  applyForVueRule (vueRule, rules) {
     vueRule.use.unshift({
       loader: require.resolve('./loader'),
       options: {
@@ -125,8 +137,6 @@ class VuetifyLoaderPlugin {
         delete imageRule.options
       }
     }
-
-    compiler.options.module.rules = rules
   }
 }
 


### PR DESCRIPTION
Add an option `handleAllVueLoaders` to modify all `vue-loader` rules rather than only the first one.

Fixes #106 