### PR TITLE
fix: undefined is not a function

### DIFF
--- a/lib/getVueRules.js
+++ b/lib/getVueRules.js
@@ -6,19 +6,21 @@ try {
   vueLoaderPath = require.resolve('vue-loader')
 } catch (err) {}
 
+function isVueLoader (use) {
+  return use.ident === 'vue-loader-options' ||
+    use.loader === 'vue-loader' ||
+    (vueLoaderPath && use.loader === vueLoaderPath)
+}
+
 module.exports = {
-  isVueLoader (use) {
-    return use.ident === 'vue-loader-options' ||
-      use.loader === 'vue-loader' ||
-      (vueLoaderPath && use.loader === vueLoaderPath)
-  },
+  isVueLoader,
   getVueRules (compiler) {
     const rules = compiler.options.module.rules
 
     // Naive approach without RuleSet or RuleSetCompiler
-    rules.map((rule, i) => rule.use && rule.use.find(exports.isVueLoader) ? i : null).filter(v => v != null)
+    rules.map((rule, i) => rule.use && rule.use.find(isVueLoader) ? i : null).filter(v => v != null)
 
     // find the rules that apply to vue files
-    return rules.filter(rule => rule.use && rule.use.find(exports.isVueLoader))
+    return rules.filter(rule => rule.use && rule.use.find(isVueLoader))
   }
 }


### PR DESCRIPTION
Accessing isVueLoader in exports did not work, therefor this patch
defines the function first and adds it to the exports afterwards.