### PR TITLE
fix: add check before calling find on vue rule

### DIFF
--- a/lib/getVueRules.js
+++ b/lib/getVueRules.js
@@ -1,6 +1,3 @@
-
-const webpack = require('webpack')
-
 let vueLoaderPath
 try {
   vueLoaderPath = require.resolve('vue-loader')
@@ -18,9 +15,9 @@ module.exports = {
     const rules = compiler.options.module.rules
 
     // Naive approach without RuleSet or RuleSetCompiler
-    rules.map((rule, i) => rule.use && rule.use.find(isVueLoader) ? i : null).filter(v => v != null)
+    rules.map((rule, i) => rule.use && rule.use.find && rule.use.find(isVueLoader) ? i : null).filter(v => v != null)
 
     // find the rules that apply to vue files
-    return rules.filter(rule => rule.use && rule.use.find(isVueLoader))
+    return rules.filter(rule => rule.use && rule.use.find && rule.use.find(isVueLoader))
   }
 }


### PR DESCRIPTION
This loader expects to be loaded before `vue-loader`  — at least when using Webpack 5.
You should receive the following error message when inverting the plugins' order:

```
[VuetifyLoaderPlugin Error] No matching rule for vue-loader found
Make sure there is at least one root-level rule that uses vue-loader and VuetifyLoaderPlugin is applied after VueLoaderPlugin.
```

Instead, it returns the following uninformative error message:

```
TypeError: rule.use.find is not a function
```

This PR updates `getVueRules.js` in order to return the proper error message.