### PR TITLE
Complete the usage example in README

### DIFF
--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -25,6 +25,12 @@ import { createVuetify } from 'vuetify'
 
 export default createVuetify()
 ```
+```js
+// src/main.ts
+import vuetify from '../plugins/vuetify'
+
+createApp(App).use(vuetify).mount('#app')
+```
 
 ## Style loading
 ### Customising variables


### PR DESCRIPTION
While I was figuring out how to use vite-plugin-vuetify, I found that ``use(vuetify)`` in ``main.ts`` was the missing piece to make it work. I guess this should be included in the example.