### PR TITLE
Fix sass files resolution for production builds

### DIFF
--- a/packages/vite-plugin/src/stylesPlugin.ts
+++ b/packages/vite-plugin/src/stylesPlugin.ts
@@ -124,7 +124,7 @@ export function stylesPlugin (options: Options): PluginOption {
         context = this
       }
     },
-    async resolveId (source, importer, custom) {
+    async resolveId (source, importer, { custom }) {
       if (
         importer &&
         source.endsWith('.css') &&
@@ -134,10 +134,7 @@ export function stylesPlugin (options: Options): PluginOption {
           return '\0__void__'
         } else if (options.styles === 'sass') {
           const target = source.replace(/\.css$/, '.sass')
-          return this.resolve(target, importer, {
-            skipSelf: true,
-            ...custom
-          })
+          return this.resolve(target, importer, { skipSelf: true, custom })
         } else if (options.styles === 'expose') {
           awaitResolve()
 


### PR DESCRIPTION
A Vite production build with `styles: 'sass'` fails with the following error:

```sh
> npm run build
Error: Could not load ./VApp.sass (imported by node_modules/vuetify/lib/components/VApp/VApp.mjs): ENOENT: no such file or directory, open 'E:\my-app\VApp.sass'
```

It seems caused by `source` being the relative path found in [`VApp.mjs`](https://cdn.jsdelivr.net/npm/vuetify@3.0.0-beta.4/lib/components/VApp/VApp.mjs) (i.e. `import "./VApp.css";`). 