### PR TITLE
fix: load external templates

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -71,90 +71,76 @@ module.exports = async function (content, sourceMap) {
   options.attrsMatch.push(vuetifyAttrsMatcher)
 
 
-  const qs = new URLSearchParams(this.resourceQuery)
-  if (qs.has('vue') && qs.get('type') === 'template') {
-    this.addDependency(this.resourcePath)
+  this.addDependency(this.resourcePath)
 
-    const matches = {
-      components: [],
-      directives: [],
-    }
+  const matches = {
+    components: [],
+    directives: [],
+  }
 
-    const ast = acorn.parse(content, { sourceType: 'module', ecmaVersion: 'latest' })
-    acornWalk.simple(ast, {
-      CallExpression (node) {
-        if (node.callee.name === '_c') {
-          if (node.arguments[0].type === 'Literal') {
-            matches.components.push([node.arguments[0].value, node.arguments[0].start, node.arguments[0].end])
-          }
-          if (node.arguments.length >= 2 && node.arguments[1].type === 'ObjectExpression') {
-            const props = node.arguments[1].properties
-            props.forEach(prop => {
-              if (prop.key.type === 'Identifier' && prop.key.name === 'directives' && prop.value.type === 'ArrayExpression') {
-                prop.value.elements.forEach(directive => {
-                  if (directive.type === 'ObjectExpression') {
-                    directive.properties.forEach(prop => {
-                      if (prop.key.type === 'Identifier' && prop.key.name === 'name') {
-                        matches.directives.push([prop.value.value, prop.start, prop.end])
-                      }
-                    })
-                  }
-                })
-              }
-            })
-          }
+  const ast = acorn.parse(content, { sourceType: 'module', ecmaVersion: 'latest' })
+  acornWalk.simple(ast, {
+    CallExpression (node) {
+      if (node.callee.name === '_c') {
+        if (node.arguments[0].type === 'Literal') {
+          matches.components.push([node.arguments[0].value, node.arguments[0].start, node.arguments[0].end])
+        }
+        if (node.arguments.length >= 2 && node.arguments[1].type === 'ObjectExpression') {
+          const props = node.arguments[1].properties
+          props.forEach(prop => {
+            if (prop.key.type === 'Identifier' && prop.key.name === 'directives' && prop.value.type === 'ArrayExpression') {
+              prop.value.elements.forEach(directive => {
+                if (directive.type === 'ObjectExpression') {
+                  directive.properties.forEach(prop => {
+                    if (prop.key.type === 'Identifier' && prop.key.name === 'name') {
+                      matches.directives.push([prop.value.value, prop.start, prop.end])
+                    }
+                  })
+                }
+              })
+            }
+          })
         }
       }
-    })
-
-    const components = getMatches.call(this, 'Tag', dedupe(matches.components), options.match)
-    const directives = getMatches.call(this, 'Attr', dedupe(matches.directives), options.attrsMatch)
-
-    const allMatches = [...matches.components.map(v => ({
-      type: 'component',
-      name: capitalize(camelize(v[0])),
-      start: v[1],
-      end: v[2],
-    })), ...matches.directives.map(v => ({
-      type: 'directive',
-      name: capitalize(camelize(v[0])),
-      start: v[1],
-      end: v[2],
-    }))].sort((a, b) => a.start - b.start)
-
-    for (let i = allMatches.length - 1; i >= 0; i--) {
-      const tag = allMatches[i]
-      if (tag.type === 'component') {
-        if (!components.some(c => c[0] === tag.name)) continue
-        content = content.slice(0, tag.start) + tag.name + content.slice(tag.end)
-      } else {
-        if (!directives.some(c => c[0] === tag.name)) continue
-        const indent = content.slice(0, tag.start).match(/\s*$/)[0]
-        content = content.slice(0, tag.start) +
-          'def: ' + tag.name + ',' +
-          indent + content.slice(tag.start)
-      }
     }
+  })
 
-    const imports = [...components, ...directives]
-    if (imports.length) {
-      content = imports.map(v => v[1]).join('\n') + '\n\n' + content
-    }
+  const components = getMatches.call(this, 'Tag', dedupe(matches.components), options.match)
+  const directives = getMatches.call(this, 'Attr', dedupe(matches.directives), options.attrsMatch)
 
-    if (options.registerStylesSSR) {
-      content += injectStylesSSR(imports)
-    }
-  } else if (options.registerStylesSSR && !this.resourceQuery) {
-    this.addDependency(this.resourcePath)
-    const newContent = 'if (render._vuetifyStyles) { render._vuetifyStyles(component) }'
+  const allMatches = [...matches.components.map(v => ({
+    type: 'component',
+    name: capitalize(camelize(v[0])),
+    start: v[1],
+    end: v[2],
+  })), ...matches.directives.map(v => ({
+    type: 'directive',
+    name: capitalize(camelize(v[0])),
+    start: v[1],
+    end: v[2],
+  }))].sort((a, b) => a.start - b.start)
 
-    // Insert our modification before the HMR code
-    const hotReload = content.indexOf('/* hot reload */')
-    if (hotReload > -1) {
-      content = content.slice(0, hotReload) + newContent + '\n\n' + content.slice(hotReload)
+  for (let i = allMatches.length - 1; i >= 0; i--) {
+    const tag = allMatches[i]
+    if (tag.type === 'component') {
+      if (!components.some(c => c[0] === tag.name)) continue
+      content = content.slice(0, tag.start) + tag.name + content.slice(tag.end)
     } else {
-      content += '\n\n' + newContent
+      if (!directives.some(c => c[0] === tag.name)) continue
+      const indent = content.slice(0, tag.start).match(/\s*$/)[0]
+      content = content.slice(0, tag.start) +
+        'def: ' + tag.name + ',' +
+        indent + content.slice(tag.start)
     }
+  }
+
+  const imports = [...components, ...directives]
+  if (imports.length) {
+    content = imports.map(v => v[1]).join('\n') + '\n\n' + content
+  }
+
+  if (options.registerStylesSSR) {
+    content += injectStylesSSR(imports)
   }
 
   this.callback(null, content, sourceMap)

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -70,77 +70,79 @@ module.exports = async function (content, sourceMap) {
   options.match.push(vuetifyMatcher)
   options.attrsMatch.push(vuetifyAttrsMatcher)
 
+  const qs = new URLSearchParams(this.resourceQuery)
+  if (qs.has('vue') && qs.get('type') === 'template') {
+    this.addDependency(this.resourcePath)
 
-  this.addDependency(this.resourcePath)
+    const matches = {
+      components: [],
+      directives: [],
+    }
 
-  const matches = {
-    components: [],
-    directives: [],
-  }
-
-  const ast = acorn.parse(content, { sourceType: 'module', ecmaVersion: 'latest' })
-  acornWalk.simple(ast, {
-    CallExpression (node) {
-      if (node.callee.name === '_c') {
-        if (node.arguments[0].type === 'Literal') {
-          matches.components.push([node.arguments[0].value, node.arguments[0].start, node.arguments[0].end])
-        }
-        if (node.arguments.length >= 2 && node.arguments[1].type === 'ObjectExpression') {
-          const props = node.arguments[1].properties
-          props.forEach(prop => {
-            if (prop.key.type === 'Identifier' && prop.key.name === 'directives' && prop.value.type === 'ArrayExpression') {
-              prop.value.elements.forEach(directive => {
-                if (directive.type === 'ObjectExpression') {
-                  directive.properties.forEach(prop => {
-                    if (prop.key.type === 'Identifier' && prop.key.name === 'name') {
-                      matches.directives.push([prop.value.value, prop.start, prop.end])
-                    }
-                  })
-                }
-              })
-            }
-          })
+    const ast = acorn.parse(content, { sourceType: 'module', ecmaVersion: 'latest' })
+    acornWalk.simple(ast, {
+      CallExpression (node) {
+        if (node.callee.name === '_c') {
+          if (node.arguments[0].type === 'Literal') {
+            matches.components.push([node.arguments[0].value, node.arguments[0].start, node.arguments[0].end])
+          }
+          if (node.arguments.length >= 2 && node.arguments[1].type === 'ObjectExpression') {
+            const props = node.arguments[1].properties
+            props.forEach(prop => {
+              if (prop.key.type === 'Identifier' && prop.key.name === 'directives' && prop.value.type === 'ArrayExpression') {
+                prop.value.elements.forEach(directive => {
+                  if (directive.type === 'ObjectExpression') {
+                    directive.properties.forEach(prop => {
+                      if (prop.key.type === 'Identifier' && prop.key.name === 'name') {
+                        matches.directives.push([prop.value.value, prop.start, prop.end])
+                      }
+                    })
+                  }
+                })
+              }
+            })
+          }
         }
       }
+    })
+
+    const components = getMatches.call(this, 'Tag', dedupe(matches.components), options.match)
+    const directives = getMatches.call(this, 'Attr', dedupe(matches.directives), options.attrsMatch)
+
+    const allMatches = [...matches.components.map(v => ({
+      type: 'component',
+      name: capitalize(camelize(v[0])),
+      start: v[1],
+      end: v[2],
+    })), ...matches.directives.map(v => ({
+      type: 'directive',
+      name: capitalize(camelize(v[0])),
+      start: v[1],
+      end: v[2],
+    }))].sort((a, b) => a.start - b.start)
+
+    for (let i = allMatches.length - 1; i >= 0; i--) {
+      const tag = allMatches[i]
+      if (tag.type === 'component') {
+        if (!components.some(c => c[0] === tag.name)) continue
+        content = content.slice(0, tag.start) + tag.name + content.slice(tag.end)
+      } else {
+        if (!directives.some(c => c[0] === tag.name)) continue
+        const indent = content.slice(0, tag.start).match(/\s*$/)[0]
+        content = content.slice(0, tag.start) +
+          'def: ' + tag.name + ',' +
+          indent + content.slice(tag.start)
+      }
     }
-  })
 
-  const components = getMatches.call(this, 'Tag', dedupe(matches.components), options.match)
-  const directives = getMatches.call(this, 'Attr', dedupe(matches.directives), options.attrsMatch)
-
-  const allMatches = [...matches.components.map(v => ({
-    type: 'component',
-    name: capitalize(camelize(v[0])),
-    start: v[1],
-    end: v[2],
-  })), ...matches.directives.map(v => ({
-    type: 'directive',
-    name: capitalize(camelize(v[0])),
-    start: v[1],
-    end: v[2],
-  }))].sort((a, b) => a.start - b.start)
-
-  for (let i = allMatches.length - 1; i >= 0; i--) {
-    const tag = allMatches[i]
-    if (tag.type === 'component') {
-      if (!components.some(c => c[0] === tag.name)) continue
-      content = content.slice(0, tag.start) + tag.name + content.slice(tag.end)
-    } else {
-      if (!directives.some(c => c[0] === tag.name)) continue
-      const indent = content.slice(0, tag.start).match(/\s*$/)[0]
-      content = content.slice(0, tag.start) +
-        'def: ' + tag.name + ',' +
-        indent + content.slice(tag.start)
+    const imports = [...components, ...directives]
+    if (imports.length) {
+      content = imports.map(v => v[1]).join('\n') + '\n\n' + content
     }
-  }
 
-  const imports = [...components, ...directives]
-  if (imports.length) {
-    content = imports.map(v => v[1]).join('\n') + '\n\n' + content
-  }
-
-  if (options.registerStylesSSR) {
-    content += injectStylesSSR(imports)
+    if (options.registerStylesSSR) {
+      content += injectStylesSSR(imports)
+    }
   }
 
   this.callback(null, content, sourceMap)

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -70,79 +70,76 @@ module.exports = async function (content, sourceMap) {
   options.match.push(vuetifyMatcher)
   options.attrsMatch.push(vuetifyAttrsMatcher)
 
-  const qs = new URLSearchParams(this.resourceQuery)
-  if (qs.has('vue') && qs.get('type') === 'template') {
-    this.addDependency(this.resourcePath)
+  this.addDependency(this.resourcePath)
 
-    const matches = {
-      components: [],
-      directives: [],
-    }
+  const matches = {
+    components: [],
+    directives: [],
+  }
 
-    const ast = acorn.parse(content, { sourceType: 'module', ecmaVersion: 'latest' })
-    acornWalk.simple(ast, {
-      CallExpression (node) {
-        if (node.callee.name === '_c') {
-          if (node.arguments[0].type === 'Literal') {
-            matches.components.push([node.arguments[0].value, node.arguments[0].start, node.arguments[0].end])
-          }
-          if (node.arguments.length >= 2 && node.arguments[1].type === 'ObjectExpression') {
-            const props = node.arguments[1].properties
-            props.forEach(prop => {
-              if (prop.key.type === 'Identifier' && prop.key.name === 'directives' && prop.value.type === 'ArrayExpression') {
-                prop.value.elements.forEach(directive => {
-                  if (directive.type === 'ObjectExpression') {
-                    directive.properties.forEach(prop => {
-                      if (prop.key.type === 'Identifier' && prop.key.name === 'name') {
-                        matches.directives.push([prop.value.value, prop.start, prop.end])
-                      }
-                    })
-                  }
-                })
-              }
-            })
-          }
+  const ast = acorn.parse(content, { sourceType: 'module', ecmaVersion: 'latest' })
+  acornWalk.simple(ast, {
+    CallExpression (node) {
+      if (node.callee.name === '_c') {
+        if (node.arguments[0].type === 'Literal') {
+          matches.components.push([node.arguments[0].value, node.arguments[0].start, node.arguments[0].end])
+        }
+        if (node.arguments.length >= 2 && node.arguments[1].type === 'ObjectExpression') {
+          const props = node.arguments[1].properties
+          props.forEach(prop => {
+            if (prop.key.type === 'Identifier' && prop.key.name === 'directives' && prop.value.type === 'ArrayExpression') {
+              prop.value.elements.forEach(directive => {
+                if (directive.type === 'ObjectExpression') {
+                  directive.properties.forEach(prop => {
+                    if (prop.key.type === 'Identifier' && prop.key.name === 'name') {
+                      matches.directives.push([prop.value.value, prop.start, prop.end])
+                    }
+                  })
+                }
+              })
+            }
+          })
         }
       }
-    })
-
-    const components = getMatches.call(this, 'Tag', dedupe(matches.components), options.match)
-    const directives = getMatches.call(this, 'Attr', dedupe(matches.directives), options.attrsMatch)
-
-    const allMatches = [...matches.components.map(v => ({
-      type: 'component',
-      name: capitalize(camelize(v[0])),
-      start: v[1],
-      end: v[2],
-    })), ...matches.directives.map(v => ({
-      type: 'directive',
-      name: capitalize(camelize(v[0])),
-      start: v[1],
-      end: v[2],
-    }))].sort((a, b) => a.start - b.start)
-
-    for (let i = allMatches.length - 1; i >= 0; i--) {
-      const tag = allMatches[i]
-      if (tag.type === 'component') {
-        if (!components.some(c => c[0] === tag.name)) continue
-        content = content.slice(0, tag.start) + tag.name + content.slice(tag.end)
-      } else {
-        if (!directives.some(c => c[0] === tag.name)) continue
-        const indent = content.slice(0, tag.start).match(/\s*$/)[0]
-        content = content.slice(0, tag.start) +
-          'def: ' + tag.name + ',' +
-          indent + content.slice(tag.start)
-      }
     }
+  })
 
-    const imports = [...components, ...directives]
-    if (imports.length) {
-      content = imports.map(v => v[1]).join('\n') + '\n\n' + content
-    }
+  const components = getMatches.call(this, 'Tag', dedupe(matches.components), options.match)
+  const directives = getMatches.call(this, 'Attr', dedupe(matches.directives), options.attrsMatch)
 
-    if (options.registerStylesSSR) {
-      content += injectStylesSSR(imports)
+  const allMatches = [...matches.components.map(v => ({
+    type: 'component',
+    name: capitalize(camelize(v[0])),
+    start: v[1],
+    end: v[2],
+  })), ...matches.directives.map(v => ({
+    type: 'directive',
+    name: capitalize(camelize(v[0])),
+    start: v[1],
+    end: v[2],
+  }))].sort((a, b) => a.start - b.start)
+
+  for (let i = allMatches.length - 1; i >= 0; i--) {
+    const tag = allMatches[i]
+    if (tag.type === 'component') {
+      if (!components.some(c => c[0] === tag.name)) continue
+      content = content.slice(0, tag.start) + tag.name + content.slice(tag.end)
+    } else {
+      if (!directives.some(c => c[0] === tag.name)) continue
+      const indent = content.slice(0, tag.start).match(/\s*$/)[0]
+      content = content.slice(0, tag.start) +
+        'def: ' + tag.name + ',' +
+        indent + content.slice(tag.start)
     }
+  }
+
+  const imports = [...components, ...directives]
+  if (imports.length) {
+    content = imports.map(v => v[1]).join('\n') + '\n\n' + content
+  }
+
+  if (options.registerStylesSSR) {
+    content += injectStylesSSR(imports)
   }
 
   this.callback(null, content, sourceMap)

--- a/lib/loaderStyleSSR.js
+++ b/lib/loaderStyleSSR.js
@@ -1,0 +1,13 @@
+module.exports = function (content) {
+  this.addDependency(this.resourcePath)
+  const newContent = 'if (render._vuetifyStyles) { render._vuetifyStyles(component) }'
+
+  // Insert our modification before the HMR code
+  const hotReload = content.indexOf('/* hot reload */')
+  if (hotReload > -1) {
+    content = content.slice(0, hotReload) + newContent + '\n\n' + content.slice(hotReload)
+  } else {
+    content += '\n\n' + newContent
+  }
+  return content
+}

--- a/lib/loaderStyleSSR.js
+++ b/lib/loaderStyleSSR.js
@@ -1,5 +1,6 @@
 module.exports = function (content) {
   this.addDependency(this.resourcePath)
+  this.cacheable()
   const newContent = 'if (render._vuetifyStyles) { render._vuetifyStyles(component) }'
 
   // Insert our modification before the HMR code

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -19,7 +19,7 @@ class VuetifyLoaderPlugin {
     }
 
     compiler.options.module.rules.unshift({
-      test: /\.vue$/,
+      resourceQuery: /vue&type=template/,
       use: {
         loader: require.resolve('./loader'),
         options: {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -18,6 +18,16 @@ class VuetifyLoaderPlugin {
       )
     }
 
+    if (this.options.registerStylesSSR) {
+      compiler.options.module.rules.unshift({
+        test: /\.vue$/,
+        resourceQuery: /^$/,
+        use: {
+          loader: require.resolve('./loaderStyleSSR'),
+        }
+      })
+    }
+
     compiler.options.module.rules.unshift({
       resourceQuery: /vue&type=template/,
       use: {


### PR DESCRIPTION
I separated the main condition of the loader into two loaders, since that condition is made on the resourceQuery of the module

Like this the vue template loader can be applied to all files (including external html, pug etc) and not just vue files

And the styleSSR loader will run on all vue files without resourceQuery