### PR TITLE
fix: load virtual requests with `?v=` query string

### DIFF
--- a/packages/vite-plugin/src/stylesPlugin.ts
+++ b/packages/vite-plugin/src/stylesPlugin.ts
@@ -173,7 +173,7 @@ export function stylesPlugin (options: Options): PluginOption {
     load (id) {
       // When Vite is configured with `optimizeDeps.exclude: ['vuetify']`, the
       // received id contains a version hash (e.g. \0__void__?v=893fa859).
-      if (/^\0?__void__(\?.*)?$/.test(id)) {
+      if (/^\0__void__(\?.*)?$/.test(id)) {
         return ''
       }
 

--- a/packages/vite-plugin/src/stylesPlugin.ts
+++ b/packages/vite-plugin/src/stylesPlugin.ts
@@ -171,7 +171,9 @@ export function stylesPlugin (options: Options): PluginOption {
       }
     },
     load (id) {
-      if (id === '__void__' || id === '\0__void__') {
+      // When Vite is configured with `optimizeDeps.exclude: ['vuetify']`, the
+      // received id contains a version hash (e.g. \0__void__?v=893fa859).
+      if (/^\0?__void__(\?.*)?$/.test(id)) {
         return ''
       }
 


### PR DESCRIPTION
When running the `dev` app in the browser (`yarn run dev:vite` from `/dev`), I'm getting the following console error:

```js
GET http://localhost:3000/@id/__x00____void__?v=893fa859 net::ERR_ABORTED 404 (Not Found)
```

That's because the `\0__void__` id isn't recognized by the `load` method because of the `?v=893fa859` suffix. This is an [hash injected by Vite](https://github.com/vitejs/vite/blob/752af6ce18b2ed01ea8d233665ca31faf0e223d3/packages/vite/src/node/plugins/resolve.ts#L725) to handle `optimizeDeps.exclude` entries. I think this issue has been introduced by 29039f37eca66c8c46744fd87c6d181af9e9d64b, though not sure why @KaelWD you didn't experience it while running the app.