### PR TITLE
fix: cache importers invalidation on Windows

### DIFF
--- a/packages/vite-plugin/src/stylesPlugin.ts
+++ b/packages/vite-plugin/src/stylesPlugin.ts
@@ -1,8 +1,8 @@
 import { utimes } from 'fs/promises'
 import * as path from 'upath'
 import _debug from 'debug'
-import { cacheDir, writeStyles, resolveVuetifyBase } from '@vuetify/loader-shared'
 import { normalizePath } from 'vite'
+import { cacheDir, writeStyles, resolveVuetifyBase } from '@vuetify/loader-shared'
 
 import type { Plugin, ViteDevServer } from 'vite'
 import type { Options } from '@vuetify/loader-shared'

--- a/packages/vite-plugin/src/stylesPlugin.ts
+++ b/packages/vite-plugin/src/stylesPlugin.ts
@@ -2,6 +2,7 @@ import { utimes } from 'fs/promises'
 import * as path from 'upath'
 import _debug from 'debug'
 import { cacheDir, writeStyles, resolveVuetifyBase } from '@vuetify/loader-shared'
+import { normalizePath } from 'vite'
 
 import type { Plugin, ViteDevServer } from 'vite'
 import type { Options } from '@vuetify/loader-shared'
@@ -98,11 +99,13 @@ export function stylesPlugin (options: Options): Plugin {
       await writeStyles(files)
 
       if (server && needsTouch) {
-        server.moduleGraph.getModulesByFile(cacheDir('styles.scss'))?.forEach(module => {
+        const cacheFile = normalizePath(cacheDir('styles.scss'))
+        server.moduleGraph.getModulesByFile(cacheFile)?.forEach(module => {
           module.importers.forEach(module => {
             if (module.file) {
+              const now = new Date()
               debug(`touching ${module.file}`)
-              utimes(module.file, Date.now(), Date.now())
+              utimes(module.file, now, now)
             }
           })
         })


### PR DESCRIPTION
On Windows, cache importers are not invalidated because `cacheDir()` returns win32 separators instead of POSIX separators, thus calling `getModulesByFile()` fails to match modules by filename. [Vite suggests to use `normalizePath`](https://v2.vitejs.dev/guide/api-plugin.html#path-normalization) for comparing paths against resolved ids.

Also, `utimes` throws on Windows because [it expects seconds instead of milliseconds]( https://github.com/nodejs/node/issues/33227#issuecomment-623391936). Using `new Date()` should fixes this issue on all platforms (tested on Windows only).

Finally, I find a bit weird to "touch" the user source files (changing created/modified dates). I guess this is required because there is no update triggered when the cache file content changes? This seems caused by the fact that the cache file is under the `node_modules` folder which is ignored by the server watcher. An alternative (hack?) would be to manually trigger this notification:

```js
server?.watcher.emit('change', cacheDir('styles.scss'))
```
