### PR TITLE
docs(loader): add -font-family example to variable overrides

### DIFF
--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -45,6 +45,7 @@ export default createVuetify()
 ```scss
 // main.scss
 @use 'vuetify/styles' with (
+  $body-font-family: ('Open Sans', sans-serif),
   $color-pack: false,
   $utilities: false,
 );


### PR DESCRIPTION
Use of lists within a map is slightly tricky syntax-wise and it'd be helpful to have an easy example of a common use-case e.g. font-family for a multi-valued attribute so that it's easy to see how this should be configured