### PR TITLE
Fix import for windows

### DIFF
--- a/packages/vite-plugin/src/importPlugin.ts
+++ b/packages/vite-plugin/src/importPlugin.ts
@@ -1,14 +1,14 @@
 import { extname } from 'path'
 import { Plugin } from 'vite'
 import { generateImports } from '@vuetify/loader-shared'
-import { parse as parseUrl, URLSearchParams } from 'url'
+import { URL, URLSearchParams } from 'url'
 
 function parseId (id: string) {
-  const { query, pathname } = parseUrl(id)
+  const { query, pathname } = new URL(id)
 
   return {
     query: query ? Object.fromEntries(new URLSearchParams(query)) : null,
-    path: pathname ?? id
+    path: pathname.replace(/^(nuxt:)/, ''); ?? id
   }
 }
 

--- a/packages/vite-plugin/src/importPlugin.ts
+++ b/packages/vite-plugin/src/importPlugin.ts
@@ -8,7 +8,7 @@ function parseId (id: string) {
 
   return {
     query: query ? Object.fromEntries(new URLSearchParams(query)) : null,
-    path: pathname.replace(/^(nuxt:)/, ''); ?? id
+    path: pathname.replace(/^(nuxt:)/, '') ?? id
   }
 }
 


### PR DESCRIPTION
Without this fix an exception is thrown by node:url.parse when fed a url with a drive letter and a colon.

```
[plugin:vuetify:import] Invalid URL
virtual:nuxt:C:/Users/davir/code/trash/guis/web/.nuxt/nuxt.config.mjs
    at new NodeError (node:internal/errors:393:5)
    at getHostname (node:url:521:15)
    at Url.parse (node:url:390:14)
    at urlParse (node:url:147:13)
    at parseId (C:\Users\davir\code\trash\guis\web\node_modules\.pnpm\vite-plugin-vuetify@1.0.1_l54dx3ntqreabui4gzakb57alm\node_modules\vite-plugin-vuetify\dist\importPlugin.js:8:49)
    at TransformContext.transform (C:\Users\davir\code\trash\guis\web\node_modules\.pnpm\vite-plugin-vuetify@1.0.1_l54dx3ntqreabui4gzakb57alm\node_modules\vite-plugin-vuetify\dist\importPlugin.js:23:37)
    at Object.transform (file:///C:/Users/davir/code/trash/guis/web/node_modules/.pnpm/vite@3.2.5/node_modules/vite/dist/node/chunks/dep-5605cfa4.js:40534:44)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async loadAndTransform (file:///C:/Users/davir/code/trash/guis/web/node_modules/.pnpm/vite@3.2.5/node_modules/vite/dist/node/chunks/dep-5605cfa4.js:36921:29
Click outside or fix the code to dismiss.
You can also disable this overlay by setting server.hmr.overlay to false in vite.config.js.
```