### PR TITLE
build: fix vue peer dependency

### DIFF
--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -24,6 +24,7 @@
     "upath": "^2.0.1"
   },
   "peerDependencies": {
+    "vue": "^3.2.45",
     "vite": "^2.7.0 || ^3.0.0 || ^4.0.0",
     "vuetify": "^3.0.0-beta.4"
   },


### PR DESCRIPTION
# Description

`vite-plugin-vuetify` depends on `@vuetify/loader-shared`, which expects a peer dependency of `vue`.

Without the peer dependency, the loader will rely on package hoisting to place the dependencies in an accessible location which is not guaranteed to happen.

I encountered this myself while working on a monorepo that includes vue2 and vue3 packages, and got this error:

```
❯ yarn dev --host
failed to load config from [...]/vite.config.ts
error when starting dev server:
Error: @vuetify/loader-shared tried to access vue (a peer dependency) but it isn't provided by its ancestors;
this makes the require call ambiguous and unsound.

Required package: vue
Required by: @vuetify/loader-shared[...]#npm:1.7.1

Ancestor breaking the chain: vite-plugin-vuetify@[...]#npm:1.0.2
```

Sometimes this problem manifested like this instead: (including for future googlers)

```
(0 , vue_1.camelize) is not a function
4:23:39 p.m. [vite] Internal server error: (0 , vue_1.camelize) is not a function
  Plugin: vuetify:import
```

I assume it imported the wrong vue here...

# Workaround

```yml
# .yarnrc.yml
packageExtensions:
  vite-plugin-vuetify@^1.0.2:
    peerDependencies:
      vue: "^3"
```