### PR TITLE
Bump find-cache-dir to v4 - fixes vulnerability in semver@6

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/vuetifyjs/vuetify-loader/tree/master/packages/shared",
   "dependencies": {
-    "find-cache-dir": "^3.3.2",
+    "find-cache-dir": "^4.0.0",
     "upath": "^2.0.1"
   },
   "peerDependencies": {

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -22,7 +22,7 @@
     "@vuetify/loader-shared": "^1.7.1",
     "decache": "^4.6.0",
     "file-loader": "^6.2.0",
-    "find-cache-dir": "^3.3.2",
+    "find-cache-dir": "^4.0.0",
     "loader-utils": "^2.0.0",
     "mkdirp": "^1.0.4",
     "null-loader": "^4.0.1",


### PR DESCRIPTION
Fixes https://github.com/vuetifyjs/vuetify-loader/issues/308