### PR TITLE
fix: vite plugin cjs types

### DIFF
--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -16,7 +16,7 @@
     "url": "git+https://github.com/vuetifyjs/vuetify-loader.git"
   },
   "scripts": {
-    "build": "unbuild && node ../../scripts/patchCJS.mjs",
+    "build": "unbuild",
     "dev": "unbuild --stub"
   },
   "author": "Kael Watts-Deuchar",


### PR DESCRIPTION
I can also remove the cjs patch script if you want since it is only used in vite-plugin.

Current version (https://arethetypeswrong.github.io/?p=vite-plugin-vuetify%402.0.1):

![imagen](https://github.com/vuetifyjs/vuetify-loader/assets/6311119/7ac0ec18-fd61-4b68-84e1-13bbca94ca70)

With this PR:

![imagen](https://github.com/vuetifyjs/vuetify-loader/assets/6311119/8ff2b7a1-fc81-4350-898b-06335d335d3f)
