### PR TITLE
feat: handle SSR in styles plugin

### DIFF
--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@vuetify/loader-shared": "^2.0.3",
     "debug": "^4.3.3",
-    "upath": "^2.0.1"
+    "pathe": "^1.1.2"
   },
   "peerDependencies": {
     "vite": ">=5",

--- a/packages/vite-plugin/src/importPlugin.ts
+++ b/packages/vite-plugin/src/importPlugin.ts
@@ -1,5 +1,5 @@
 import { extname } from 'path'
-import { Plugin } from 'vite'
+import type { Plugin } from 'vite'
 import { generateImports, Options } from '@vuetify/loader-shared'
 import { URLSearchParams } from 'url'
 

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -1,5 +1,6 @@
-import { Plugin } from 'vite'
-import { Options, isObject, includes, transformAssetUrls } from '@vuetify/loader-shared'
+import type { Plugin } from 'vite'
+import type { Options } from '@vuetify/loader-shared'
+import { isObject, includes, transformAssetUrls } from '@vuetify/loader-shared'
 
 import { importPlugin } from './importPlugin'
 import { stylesPlugin } from './stylesPlugin'

--- a/packages/vite-plugin/src/stylesPlugin.ts
+++ b/packages/vite-plugin/src/stylesPlugin.ts
@@ -36,7 +36,7 @@ export function stylesPlugin (options: Options): Plugin {
         )
       ) {
         if (options.styles === 'none') {
-          return '\0__void__'
+          return '/@plugin-vuetify/lib/__void__'
         } else if (options.styles === 'sass') {
           const target = source.replace(/\.css$/, '.sass')
           return this.resolve(target, importer, { skipSelf: true, custom })
@@ -56,8 +56,6 @@ export function stylesPlugin (options: Options): Plugin {
               : `/@fs/plugin-vuetify/lib/${file}`
         }
       }
-
-      return null
     },
     load (id) {
       // When Vite is configured with `optimizeDeps.exclude: ['vuetify']`, the

--- a/yarn.lock
+++ b/yarn.lock
@@ -7863,6 +7863,11 @@ pathe@^1.1.0, pathe@^1.1.1:
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.1.tgz#1dd31d382b974ba69809adc9a7a347e65d84829a"
   integrity sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==
 
+pathe@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.2.tgz#6c4cb47a945692e48a1ddd6e4094d170516437ec"
+  integrity sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -10198,6 +10203,15 @@ vite-plugin-inspect@^0.8.1:
     picocolors "^1.0.0"
     sirv "^2.0.3"
 
+vite-plugin-vuetify@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/vite-plugin-vuetify/-/vite-plugin-vuetify-2.0.1.tgz#172ffb6c46fec469fa96b3df03fd11b90d48f5d6"
+  integrity sha512-GlRVAruohE8b0FqmeYYh1cYg3n8THGOv066uMA44qLv9uhUxSLw55CS7fi2yU0wH363TJ2vq36zUsPTjRFrjGQ==
+  dependencies:
+    "@vuetify/loader-shared" "^2.0.1"
+    debug "^4.3.3"
+    upath "^2.0.1"
+
 vite@^5.0.6:
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/vite/-/vite-5.0.6.tgz#f9e13503a4c5ccd67312c67803dec921f3bdea7c"
@@ -10347,6 +10361,20 @@ webpack-merge@^5.7.3:
   dependencies:
     clone-deep "^4.0.1"
     wildcard "^2.0.0"
+
+webpack-plugin-vuetify@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webpack-plugin-vuetify/-/webpack-plugin-vuetify-3.0.1.tgz#3916efdd5f67a4f58d97b7ec14093783a66edd0f"
+  integrity sha512-/FEpXPfPQlSMdJgLcz/iF6yQ82NdBwmryyACIhY5agsv0uW6/VEXmRlnBiF54MV2KW0/Vt5ZPXyhSx5r7u0lFA==
+  dependencies:
+    "@vuetify/loader-shared" "^2.0.1"
+    decache "^4.6.0"
+    file-loader "^6.2.0"
+    find-cache-dir "^5.0.0"
+    loader-utils "^2.0.0"
+    mkdirp "^1.0.4"
+    null-loader "^4.0.1"
+    upath "^2.0.1"
 
 webpack-sources@^3.2.3:
   version "3.2.3"


### PR DESCRIPTION
This PR also includes some `import type` when importing types: using `pathe` instead `upath`.

Here the reproductions (can be opened in StackBlitz, links in the corresponding readme files):
- Nuxt 3: https://github.com/userquin/nuxt3-vuetify3-issue-15412
- Vite 5: https://github.com/userquin/vite-vuetify3-plugin

EDIT: I have no idea why webpack and vite plugins added to the lock file, I just run `yarn` once dependencies updated.

(How can we run the dev folder? You should move the repo to pnpm monorepo)