### PR TITLE
feat: refactor vite styles plugin

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,6 +9,13 @@ export interface Options {
   autoImport?: ImportPluginOptions,
   styles?: true | 'none' | 'sass' | {
     configFile: string,
+    /**
+     * Enable this flag when using Vite >= 5.4.3.
+     *
+     * @see https://github.com/vitejs/vite/pull/17909
+     * @default false
+     */
+    useViteFileImport?: boolean,
   },
 }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,13 +9,6 @@ export interface Options {
   autoImport?: ImportPluginOptions,
   styles?: true | 'none' | 'sass' | {
     configFile: string,
-    /**
-     * Enable this flag when using Vite >= 5.4.3.
-     *
-     * @see https://github.com/vitejs/vite/pull/17909
-     * @default false
-     */
-    useViteFileImport?: boolean,
   },
 }
 

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -80,12 +80,12 @@ export default createVuetify()
 
 `settings.scss` can be used in your own components to access vuetify's variables.
 
-### Configure modern SASS compiler
+#### Configure modern SASS compiler
 
 Performance can be improved by using the modern SASS compiler. Replace your `sass` dependency with `sass-embedded`, update vite to 5.4 or later, and set
 [css.preprocessorOptions.sass.api](https://vitejs.dev/config/shared-options#css-preprocessoroptions) to 'modern-compiler' in the vite config.
 
-If you're using Nuxt 3 with Vite, you can configure the modern SASS compiler in the Nuxt configuration file, using [vite](https://nuxt.com/docs/api/nuxt-config#vite) option.
+If you're using Nuxt 3, you can configure the modern SASS compiler in the Nuxt configuration file using [vite](https://nuxt.com/docs/api/nuxt-config#vite) option.
 
 
 ### Remove all style imports

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -80,6 +80,14 @@ export default createVuetify()
 
 `settings.scss` can be used in your own components to access vuetify's variables.
 
+### Configure modern SASS compiler
+
+Performance can be improved by using the modern SASS compiler. Replace your `sass` dependency with `sass-embedded`, update vite to 5.4 or later, and set
+[css.preprocessorOptions.sass.api](https://vitejs.dev/config/shared-options#css-preprocessoroptions) to 'modern-compiler' in the vite config.
+
+If you're using Nuxt 3 with Vite, you can configure the modern SASS compiler in the Nuxt configuration file, using [vite](https://nuxt.com/docs/api/nuxt-config#vite) option.
+
+
 ### Remove all style imports
 ```js
 // vite.config.js

--- a/packages/vite-plugin/src/stylesPlugin.ts
+++ b/packages/vite-plugin/src/stylesPlugin.ts
@@ -25,7 +25,7 @@ export function stylesPlugin (options: Options): Plugin {
           configFile = path.resolve(path.join(config.root || process.cwd(), options.styles.configFile))
         }
         configFile = useFileImport
-          ? pathToFileURL(configFile!).href
+          ? pathToFileURL(configFile).href
           : normalizePath(configFile)
       }
     },

--- a/packages/vite-plugin/src/stylesPlugin.ts
+++ b/packages/vite-plugin/src/stylesPlugin.ts
@@ -1,6 +1,7 @@
 import path from 'upath'
 import { resolveVuetifyBase, normalizePath, isObject } from '@vuetify/loader-shared'
 import type { Plugin } from 'vite'
+import { version as VITE_VERSION } from 'vite'
 import type { Options } from '@vuetify/loader-shared'
 import { pathToFileURL } from 'node:url'
 
@@ -12,16 +13,20 @@ export function stylesPlugin (options: Options): Plugin {
   let sassVariables = false
   let fileImport = false
   const PREFIX = 'vuetify-styles/'
-  const SSR_PREFIX = '/@vuetify-styles/'
+  const SSR_PREFIX = `/@${PREFIX}`
 
   return {
     name: 'vuetify:styles',
     enforce: 'pre',
     configResolved (config) {
-      isNone = options.styles === 'none'
       if (isObject(options.styles)) {
         sassVariables = true
-        fileImport = options.styles.useViteFileImport === true
+        const [major, minor, patch] = VITE_VERSION.split('.')
+            .map((v: string) => v.includes('-') ? v.split('-')[0] : v)
+            .map(v => Number.parseInt(v))
+        // use file import when vite version > 5.4.2
+        // check https://github.com/vitejs/vite/pull/17909
+        fileImport = major > 5 || (major === 5 && minor > 4) || (major === 5 && minor === 4 && patch > 2)
         configFile = path.isAbsolute(options.styles.configFile)
           ? path.resolve(options.styles.configFile)
           : path.resolve(path.join(config.root || process.cwd(), options.styles.configFile))
@@ -29,10 +34,18 @@ export function stylesPlugin (options: Options): Plugin {
           ? pathToFileURL(configFile).href
           : normalizePath(configFile)
       }
+      else {
+        isNone = options.styles === 'none'
+      }
     },
     async resolveId (source, importer, { custom, ssr }) {
       if (source.startsWith(PREFIX) || source.startsWith(SSR_PREFIX)) {
-        return source
+        if (source.endsWith('.sass')) {
+          return source
+        }
+
+        const idx = source.indexOf('?')
+        return idx > -1 ? source.slice(0, idx) : source
       }
 
       if (

--- a/packages/vite-plugin/src/stylesPlugin.ts
+++ b/packages/vite-plugin/src/stylesPlugin.ts
@@ -29,7 +29,7 @@ export function stylesPlugin (options: Options): Plugin {
           : normalizePath(configFile)
       }
     },
-    async resolveId (source, importer, { custom }) {
+    async resolveId (source, importer, { custom, ssr }) {
       if (
         source === 'vuetify/styles' || (
           importer &&
@@ -54,7 +54,10 @@ export function stylesPlugin (options: Options): Plugin {
           return target
         }
 
-        return `${PREFIX}${path.relative(vuetifyBase, target)}`
+        // Avoid writing the asset in the html when SSR enabled:
+        // https://vitejs.dev/guide/features#disabling-css-injection-into-the-page
+        // This will prevent vue router warnings for the virtual sass file in Nuxt with SSR enabled.
+        return `${PREFIX}${path.relative(vuetifyBase, target)}${ssr ? '?inline' : ''}`
       }
 
       return undefined

--- a/packages/vite-plugin/src/stylesPlugin.ts
+++ b/packages/vite-plugin/src/stylesPlugin.ts
@@ -25,8 +25,8 @@ export function stylesPlugin (options: Options): Plugin {
           configFile = path.resolve(path.join(config.root || process.cwd(), options.styles.configFile))
         }
         configFile = useFileImport
-          ? normalizePath(configFile)
-          : pathToFileURL(configFile!).href
+          ? pathToFileURL(configFile!).href
+          : normalizePath(configFile)
       }
     },
     async resolveId (source, importer, { custom }) {

--- a/packages/vite-plugin/src/stylesPlugin.ts
+++ b/packages/vite-plugin/src/stylesPlugin.ts
@@ -1,34 +1,30 @@
 import path from 'upath'
 import { resolveVuetifyBase, normalizePath, isObject } from '@vuetify/loader-shared'
-
 import type { Plugin } from 'vite'
 import type { Options } from '@vuetify/loader-shared'
-
-function isSubdir (root: string, test: string) {
-  const relative = path.relative(root, test)
-  return relative && !relative.startsWith('..') && !path.isAbsolute(relative)
-}
-
-const PLUGIN_VIRTUAL_PREFIX = "virtual:"
-const PLUGIN_VIRTUAL_NAME = "plugin-vuetify"
-const VIRTUAL_MODULE_ID = `${PLUGIN_VIRTUAL_PREFIX}${PLUGIN_VIRTUAL_NAME}`
+import { pathToFileURL } from 'node:url'
 
 export function stylesPlugin (options: Options): Plugin {
   const vuetifyBase = resolveVuetifyBase()
 
-  let configFile: string
+  let configFile: string | undefined
   const tempFiles = new Map<string, string>()
+  const isNone = options.styles === 'none'
+  const sassVariables = isNone ? false : isObject(options.styles)
+  let useFileImport = false
 
   return {
     name: 'vuetify:styles',
     enforce: 'pre',
     configResolved (config) {
       if (isObject(options.styles)) {
+        useFileImport = options.styles.useViteFileImport === true
         if (path.isAbsolute(options.styles.configFile)) {
-          configFile = options.styles.configFile
+          configFile = path.resolve(options.styles.configFile)
         } else {
-          configFile = path.join(config.root || process.cwd(), options.styles.configFile)
+          configFile = path.resolve(path.join(config.root || process.cwd(), options.styles.configFile))
         }
+        configFile = normalizePath(configFile)
       }
     },
     async resolveId (source, importer, { custom }) {
@@ -39,48 +35,35 @@ export function stylesPlugin (options: Options): Plugin {
           isSubdir(vuetifyBase, path.isAbsolute(source) ? source : importer)
         )
       ) {
-        if (options.styles === 'none') {
-          return `${PLUGIN_VIRTUAL_PREFIX}__void__`
-        } else if (options.styles === 'sass') {
+        if (options.styles === 'sass') {
           const target = source.replace(/\.css$/, '.sass')
           return this.resolve(target, importer, { skipSelf: true, custom })
-        } else if (isObject(options.styles)) {
-          const resolution = await this.resolve(source, importer, { skipSelf: true, custom })
-
-          if (!resolution) return null
-
-          const target = resolution.id.replace(/\.css$/, '.sass')
-          const file = path.relative(path.join(vuetifyBase, 'lib'), target)
-          const contents = `@use "${normalizePath(configFile)}"\n@use "${normalizePath(target)}"`
-
-          tempFiles.set(file, contents)
-
-          return `${VIRTUAL_MODULE_ID}:${file}`
         }
-      } else if (source.startsWith(`/${PLUGIN_VIRTUAL_NAME}:`)) {
-        return PLUGIN_VIRTUAL_PREFIX + source.slice(1)
-      } else if (source.startsWith(`/@id/__x00__${PLUGIN_VIRTUAL_NAME}:`)) {
-        return PLUGIN_VIRTUAL_PREFIX + source.slice(12)
-      } else if (source.startsWith(`/${VIRTUAL_MODULE_ID}:`)) {
-        return source.slice(1)
+
+        const resolution = await this.resolve(source, importer, { skipSelf: true, custom })
+
+        if (!resolution) return null
+
+        const target = resolution.id.replace(/\.css$/, '.sass')
+        tempFiles.set(target, isNone
+            ? '' :
+            useFileImport
+                ? `@use "${pathToFileURL(configFile!).href}"\n@use "${pathToFileURL(target).href}"`
+                : `@use "${normalizePath(configFile!)}"\n@use "${normalizePath(target)}"`
+        )
+
+        return target
       }
 
-      return null
+      return undefined
     },
     load (id) {
-      // When Vite is configured with `optimizeDeps.exclude: ['vuetify']`, the
-      // received id contains a version hash (e.g. \0__void__?v=893fa859).
-      if (new RegExp(`^${PLUGIN_VIRTUAL_PREFIX}__void__(\\?.*)?$`).test(id)) {
-        return ''
-      }
-
-      if (id.startsWith(`${VIRTUAL_MODULE_ID}`)) {
-        const file = new RegExp(`^${VIRTUAL_MODULE_ID}:(.*?)(\\?.*)?$`).exec(id)![1]
-
-        return tempFiles.get(file)
-      }
-
-      return null
+      return isNone || sassVariables ? tempFiles.get(id) : undefined
     },
   }
+}
+
+function isSubdir (root: string, test: string) {
+  const relative = path.relative(root, test)
+  return relative && !relative.startsWith('..') && !path.isAbsolute(relative)
 }

--- a/packages/vite-plugin/src/stylesPlugin.ts
+++ b/packages/vite-plugin/src/stylesPlugin.ts
@@ -67,19 +67,19 @@ export function stylesPlugin (options: Options): Plugin {
     load (id) {
       if (sassVariables) {
         const target = id.startsWith(PREFIX)
-            ? path.resolve(vuetifyBase, id.slice(PREFIX.length))
-            : id.startsWith(SSR_PREFIX)
-                ? path.resolve(vuetifyBase, id.slice(SSR_PREFIX.length))
-                : undefined
+          ? path.resolve(vuetifyBase, id.slice(PREFIX.length))
+          : id.startsWith(SSR_PREFIX)
+            ? path.resolve(vuetifyBase, id.slice(SSR_PREFIX.length))
+            : undefined
 
-            if (target) {
-              return {
-                code: `@use "${configFile}"\n@use "${fileImport ? pathToFileURL(target).href : normalizePath(target)}"`,
-                map: {
-                  mappings: '',
-                },
-              }
-            }
+        if (target) {
+          return {
+            code: `@use "${configFile}"\n@use "${fileImport ? pathToFileURL(target).href : normalizePath(target)}"`,
+            map: {
+              mappings: '',
+            },
+          }
+        }
       }
       return isNone && noneFiles.has(id) ? '' : undefined
     },

--- a/packages/vite-plugin/src/stylesPlugin.ts
+++ b/packages/vite-plugin/src/stylesPlugin.ts
@@ -11,20 +11,20 @@ export function stylesPlugin (options: Options): Plugin {
   const tempFiles = new Map<string, string>()
   const isNone = options.styles === 'none'
   const sassVariables = isNone ? false : isObject(options.styles)
-  let useFileImport = false
+  let fileImport = false
 
   return {
     name: 'vuetify:styles',
     enforce: 'pre',
     configResolved (config) {
       if (isObject(options.styles)) {
-        useFileImport = options.styles.useViteFileImport === true
+        fileImport = options.styles.useViteFileImport === true
         if (path.isAbsolute(options.styles.configFile)) {
           configFile = path.resolve(options.styles.configFile)
         } else {
           configFile = path.resolve(path.join(config.root || process.cwd(), options.styles.configFile))
         }
-        configFile = useFileImport
+        configFile = fileImport
           ? pathToFileURL(configFile).href
           : normalizePath(configFile)
       }
@@ -50,10 +50,8 @@ export function stylesPlugin (options: Options): Plugin {
 
         const target = resolution.id.replace(/\.css$/, '.sass')
         tempFiles.set(target, isNone
-            ? '' :
-            useFileImport
-                ? `@use "${configFile}"\n@use "${pathToFileURL(target).href}"`
-                : `@use "${configFile}"\n@use "${normalizePath(target)}"`
+            ? ''
+            : `@use "${configFile}"\n@use "${fileImport ? pathToFileURL(target).href : normalizePath(target)}"`
         )
 
         return target

--- a/packages/vite-plugin/src/stylesPlugin.ts
+++ b/packages/vite-plugin/src/stylesPlugin.ts
@@ -62,9 +62,11 @@ export function stylesPlugin (options: Options): Plugin {
 
       return undefined
     },
-    load (id) {
+    load (id, options) {
       if (sassVariables && id.startsWith(PREFIX)) {
-        const target = path.resolve(vuetifyBase, id.slice(PREFIX.length))
+        let target = path.resolve(vuetifyBase, id.slice(PREFIX.length))
+        if (options?.ssr)
+          target = target.replace(/\?inline$/, '')
         return {
           code: `@use "${configFile}"\n@use "${fileImport ? pathToFileURL(target).href : normalizePath(target)}"`,
           map: {


### PR DESCRIPTION
This PR includes:
- simplify virtual logic: ~~refactor logic to remove any virtual usage: using target mapping from `.css`  to `.sass` + writing temporary SASS files when using SASS Variables (will solve missing sass source warnings and SSR problems when using Nuxt)~~ ✔️ we only need to fix vue router warnings when running Nuxt with SSR enabled
- handle `none` and object styles notation at once
- include `useViteFileImport` in shared options
- docs: include similar hint to Vuetify docs in readme file

You can check the following repos and the corresponding PR:
- https://github.com/userquin/nuxt3-vuetify3-issue-15412/pull/3 (Nuxt)
- https://github.com/userquin/vuetify-vite-modern-sass/pull/3 (Vite)

supersedes #332