### PR TITLE
feat: add `unplugin-vuetify` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   ],
   "scripts": {
     "lint": "eslint packages/*/src/**/* && tsc --noEmit",
+    "lint:fix": "eslint packages/*/src/**/* --fix",
     "dev": "lerna run dev",
+    "dev:unplugin-vuetify": "lerna run dev:unplugin-vuetify --stream --no-prefix",
     "dev:vite": "lerna run dev:vite --stream --no-prefix",
     "dev:webpack": "lerna run dev:webpack --stream --no-prefix",
     "build": "lerna run build",

--- a/packages/unplugin-vuetify/build.config.ts
+++ b/packages/unplugin-vuetify/build.config.ts
@@ -1,0 +1,23 @@
+import { defineBuildConfig } from 'unbuild'
+
+export default defineBuildConfig({
+    entries: [
+        'src/index',
+        'src/types',
+        'src/unimport-presets',
+        'src/unplugin-vue-component-resolvers',
+        'src/utils',
+    ],
+    externals: [
+        'pathe',
+        'upath',
+        'vite',
+        'vuetify',
+        'vuetify/directives',
+        'vuetify/components',
+        'vuetify/labs/components',
+        'unplugin-vue-components/types',
+    ],
+    declaration: 'node16',
+    clean: true,
+})

--- a/packages/unplugin-vuetify/build.config.ts
+++ b/packages/unplugin-vuetify/build.config.ts
@@ -5,7 +5,7 @@ export default defineBuildConfig({
         'src/index',
         'src/types',
         'src/unimport-presets',
-        'src/unplugin-vue-component-resolvers',
+        'src/unplugin-vue-components-resolvers',
         'src/utils',
     ],
     externals: [

--- a/packages/unplugin-vuetify/package.json
+++ b/packages/unplugin-vuetify/package.json
@@ -1,0 +1,91 @@
+{
+  "name": "unplugin-vuetify",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "A set of utilities for Vuetify components, directives, styles and more",
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/types.d.mts",
+  "exports": {
+    ".": "./dist/index.mjs",
+    "./types": {
+      "types": "./dist/types.d.mts"
+    },
+    "./unimport-presets": "./dist/unimport-presets.mjs",
+    "./unplugin-vue-component-resolvers": "./dist/unplugin-vue-component-resolvers.mjs",
+    "./utils": "./dist/utils.mjs"
+  },
+  "typesVersions": {
+    "*": {
+      "types": [
+        "dist/types.d.mts"
+      ],
+      "unimport-presets": [
+        "dist/unimport-presets.d.mts"
+      ],
+      "unplugin-vue-component-resolvers": [
+        "dist/unplugin-vue-component-resolvers.d.mts"
+      ],
+      "utils": [
+        "dist/utils.d.mts"
+      ]
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vuetifyjs/vuetify-loader.git"
+  },
+  "scripts": {
+    "build": "unbuild",
+    "dev": "unbuild --stub"
+  },
+  "author": "Kael Watts-Deuchar",
+  "contributors": [
+    {
+      "name": "Joaquín Sánchez <userquin@gmail.com> @userquin"
+    }
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/vuetifyjs/vuetify-loader/issues"
+  },
+  "homepage": "https://github.com/vuetifyjs/vuetify-loader/tree/master/packages/vite-plugin",
+  "dependencies": {
+    "debug": "^4.4.0",
+    "pathe": "2.0.3",
+    "upath": "^2.0.1"
+  },
+  "peerDependencies": {
+    "unimport": "^4.0.0 || ^5.0.0",
+    "unplugin-vue-components": "^28.4.1",
+    "vite": "^5.0.0 || ^6.0.0",
+    "vue": "^3.0.0",
+    "vuetify": "^3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "unimport": {
+      "optional": true
+    },
+    "unplugin-vue-components": {
+      "optional": true
+    },
+    "vite": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "unbuild": "^2.0.0",
+    "unimport": "^5.0.0",
+    "unplugin-vue-components": "^28.4.1",
+    "vite": "^5.0.0"
+  },
+  "engines": {
+    "node": "^18.0.0 || >=20.0.0"
+  },
+  "files": [
+    "dist/"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/unplugin-vuetify/package.json
+++ b/packages/unplugin-vuetify/package.json
@@ -5,14 +5,14 @@
   "description": "A set of utilities for Vuetify components, directives, styles and more",
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
-  "types": "./dist/types.d.mts",
+  "types": "./dist/index.d.mts",
   "exports": {
     ".": "./dist/index.mjs",
     "./types": {
       "types": "./dist/types.d.mts"
     },
     "./unimport-presets": "./dist/unimport-presets.mjs",
-    "./unplugin-vue-component-resolvers": "./dist/unplugin-vue-component-resolvers.mjs",
+    "./unplugin-vue-components-resolvers": "./dist/unplugin-vue-components-resolvers.mjs",
     "./utils": "./dist/utils.mjs"
   },
   "typesVersions": {
@@ -23,8 +23,8 @@
       "unimport-presets": [
         "dist/unimport-presets.d.mts"
       ],
-      "unplugin-vue-component-resolvers": [
-        "dist/unplugin-vue-component-resolvers.d.mts"
+      "unplugin-vue-components-resolvers": [
+        "dist/unplugin-vue-components-resolvers.d.mts"
       ],
       "utils": [
         "dist/utils.d.mts"

--- a/packages/unplugin-vuetify/src/index.ts
+++ b/packages/unplugin-vuetify/src/index.ts
@@ -1,0 +1,202 @@
+import type { PluginOption } from 'vite'
+import process from 'node:process'
+import fs from 'node:fs'
+import fsp from 'node:fs/promises'
+import { pathToFileURL } from 'node:url'
+import { resolveVuetifyBase } from './utils'
+import { isAbsolute, relative as relativePath } from 'pathe'
+import path from 'upath'
+import { version as VITE_VERSION } from 'vite'
+
+export interface VuetifyStylesOptions {
+  /**
+   * What CSS SASS/SCSS API should the plugin register?
+   * - `false` - don't register any SASS/SCSS API
+   * - `modern` - register SASS/SCSS 'modern' API => when using `sass`
+   * - `modern-compiler` - register SASS/SCSS 'modern-compiler' API => when using `sass-embedded`
+   *
+   * When using `modern` API, the plugin will enable `preprocessorMaxWorkers` in Vite CSS config.
+   *
+   * @default 'modern-compiler'
+   */
+  registerApi?: 'modern' | 'modern-compiler' | false
+  /**
+   * Mode to use for styles:
+   * - `none`: remove all style imports
+   * - `source`: import sass/scss from source (old `sass` option)
+   * - `configFile`: customising variables
+   */
+  mode?: true | 'none' | 'source' | {
+    configFile: string,
+  }
+}
+
+export function VuetifyStylesVitePlugin(options: VuetifyStylesOptions = {}) {
+  let configFile: string | undefined
+  // let cacheDir: string | undefined
+  const vuetifyBase = resolveVuetifyBase()
+  const noneFiles = new Set<string>()
+  let isNone = false
+  let sassVariables = false
+  let fileImport = false
+  const PREFIX = 'vuetify-styles/'
+  const SSR_PREFIX = `/@${PREFIX}`
+  const resolveCss = resolveCssFactory()
+  const api = options.registerApi ?? 'modern-compiler'
+
+  const [major, minor, patch] = VITE_VERSION.split('.')
+      .map((v: string) => v.includes('-') ? v.split('-')[0] : v)
+      .map(v => Number.parseInt(v))
+
+  return <PluginOption>{
+    name: 'unplugin-vuetify:styles',
+    enforce: 'pre',
+    config(config) {
+      if (!api)
+        return null
+
+      if (api === 'modern-compiler') {
+        return {
+          css: {
+            preprocessorOptions: {
+              sass: { api },
+              scss: { api },
+            },
+          },
+        }
+      }
+
+      if (config.css && !('preprocessorMaxWorkers' in config.css)) {
+        return {
+          css: {
+            preprocessorOptions: {
+              sass: { api },
+              scss: { api },
+            },
+          },
+        }
+      }
+
+      return {
+        css: {
+          preprocessorOptions: {
+            sass: { api },
+            scss: { api },
+          },
+          preprocessorMaxWorkers: true,
+        },
+      }
+    },
+    configResolved(config) {
+      if (config.plugins.findIndex(plugin => plugin.name === 'vuetify:styles') > -1)
+        throw new Error('Remove vite-plugin-vuetify from your Nuxt config file, this module registers a modified version.')
+
+      if (isObject(options.mode)) {
+        sassVariables = true
+        // use file import when vite version > 5.4.2
+        // check https://github.com/vitejs/vite/pull/17909
+        fileImport = major > 5 || (major === 5 && minor > 4) || (major === 5 && minor === 4 && patch > 2)
+        if (path.isAbsolute(options.mode.configFile))
+          configFile = path.resolve(options.mode.configFile)
+        else
+          configFile = path.resolve(path.join(config.root || process.cwd(), options.mode.configFile))
+
+        configFile = fileImport
+            ? pathToFileURL(configFile).href
+            : normalizePath(configFile)
+      }
+      else {
+        isNone = options.mode === 'none'
+      }
+    },
+    async resolveId(source, importer, { custom, ssr }) {
+      if (source.startsWith(PREFIX) || source.startsWith(SSR_PREFIX)) {
+        if (source.match(/\.s[ca]ss$/))
+          return source
+
+        const idx = source.indexOf('?')
+        return idx > -1 ? source.slice(0, idx) : source
+      }
+
+      if (
+          source === 'vuetify/styles' || (
+              importer
+              && source.endsWith('.css')
+              && isSubdir(vuetifyBase, path.isAbsolute(source) ? source : importer)
+          )
+      ) {
+        if (options.mode === 'source')
+          return this.resolve(await resolveCss(source), importer, { skipSelf: true, custom })
+
+        const resolution = await this.resolve(source, importer, { skipSelf: true, custom })
+        if (!resolution)
+          return undefined
+
+        const target = await resolveCss(resolution.id)
+        if (isNone) {
+          noneFiles.add(target)
+          return target
+        }
+
+        return `${ssr ? SSR_PREFIX : PREFIX}${path.relative(vuetifyBase, target)}`
+      }
+
+      return undefined
+    },
+    load(id) {
+      if (sassVariables) {
+        const target = id.startsWith(PREFIX)
+            ? path.resolve(vuetifyBase, id.slice(PREFIX.length))
+            : id.startsWith(SSR_PREFIX)
+                ? path.resolve(vuetifyBase, id.slice(SSR_PREFIX.length))
+                : undefined
+
+        if (target) {
+          const suffix = target.match(/\.scss/) ? ';\n' : '\n'
+          return {
+            code: `@use "${configFile}"${suffix}@use "${fileImport ? pathToFileURL(target).href : normalizePath(target)}"${suffix}`,
+            map: {
+              mappings: '',
+            },
+          }
+        }
+      }
+      return isNone && noneFiles.has(id) ? '' : undefined
+    },
+  }
+}
+
+function resolveCssFactory() {
+  const mappings = new Map<string, string>()
+  return async (source: string) => {
+    let mapping = mappings.get(source)
+    if (!mapping) {
+      try {
+        mapping = source.replace(/\.css$/, '.sass')
+        await fsp.access(mapping, fs.constants.R_OK)
+      }
+      catch (err) {
+        if (!(err instanceof Error && 'code' in err && err.code === 'ENOENT'))
+          throw err
+        mapping = source.replace(/\.css$/, '.scss')
+      }
+      mappings.set(source, mapping)
+    }
+    return mapping
+  }
+}
+
+function isObject (value: any): value is object {
+  return value !== null && typeof value === 'object'
+}
+
+// Add leading slash to absolute paths on windows
+function normalizePath (p: string) {
+  p = path.normalize(p)
+  return /^[a-z]:\//i.test(p) ? '/' + p : p
+}
+
+function isSubdir(root: string, test: string) {
+  const relative = relativePath(root, test)
+  return relative && !relative.startsWith('..') && !isAbsolute(relative)
+}

--- a/packages/unplugin-vuetify/src/index.ts
+++ b/packages/unplugin-vuetify/src/index.ts
@@ -89,7 +89,7 @@ export function VuetifyStylesVitePlugin(options: VuetifyStylesOptions = {}) {
     },
     configResolved(config) {
       if (config.plugins.findIndex(plugin => plugin.name === 'vuetify:styles') > -1)
-        throw new Error('Remove vite-plugin-vuetify from your Nuxt config file, this module registers a modified version.')
+        throw new Error('The "vite-plugin-vuetify" styles plugin is incompatible with this plugin. Please remove "vite-plugin-vuetify" or set the styles to \'none\' in your Vite configuration file.')
 
       if (isObject(options.mode)) {
         sassVariables = true

--- a/packages/unplugin-vuetify/src/types.ts
+++ b/packages/unplugin-vuetify/src/types.ts
@@ -1,0 +1,20 @@
+export interface VuetifyComponent {
+    from: string
+}
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+export type ComponentName = keyof typeof import('vuetify/components')
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+export type LabComponentName = keyof typeof import('vuetify/labs/components')
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+export type DirectiveName = keyof typeof import('vuetify/directives')
+export interface VuetifyComponents {
+    [key: string]: VuetifyComponent
+}
+export interface ImportComponents {
+    components: VuetifyComponents
+    directives: DirectiveName[]
+}
+export interface ImportLabsComponents {
+    [key: string]: VuetifyComponent
+}
+export type ImportMaps = [importMaps: Promise<ImportComponents>, importMapsLabs: Promise<ImportLabsComponents>]

--- a/packages/unplugin-vuetify/src/unimport-presets.ts
+++ b/packages/unplugin-vuetify/src/unimport-presets.ts
@@ -1,0 +1,170 @@
+// Types
+import type { Addon, AddonsOptions, InlinePreset, PresetImport } from 'unimport'
+import type {
+    ComponentName,
+    DirectiveName,
+    LabComponentName,
+    VuetifyComponent,
+} from './types'
+import {
+    mapComponent,
+    prepareTransformAssetUrls,
+    resolveVuetifyComponentFrom,
+    resolveVuetifyImportMaps,
+    toKebabCase,
+} from './utils'
+
+export type { ComponentName, DirectiveName, LabComponentName }
+
+export interface VuetifyComponentInfo {
+    pascalName: string
+    kebabName: string
+    export: string
+    filePath: string
+}
+
+export interface VuetifyComposablesOptions {
+    /**
+     * Prefix Vuetify composables (to allow use other composables with the same name):
+     * - when prefix set to `true` will use `useV`: `useVDate`.
+     * - when prefix is a string will use `use<prefix>`: `useVuetifyDate` with `prefix: 'Vuetify'`.
+     */
+    prefix?: true | string
+}
+
+export interface VuetifyDirectivesOptions {
+    /**
+     * Prefix Vuetify directives (to allow use other directives with the same name):
+     * - when prefix set to `true` will use `Vuetify` => `v-vuetify-<directive>: `v-vuetify-ripple`.
+     */
+    prefix?: true
+    /**
+     * Directives to exclude.
+     */
+    exclude?: DirectiveName[]
+}
+
+export interface VuetifyComponentsOptions {
+    /**
+     * Prefix Vuetify components (to allow use other components with the same name):
+     * - when prefix set to `true` will use `Vuetify` => `vuetify-<component>/Vuetify<component>: `vuetify-btn/VuetifyBtn`.
+     */
+    prefix?: true
+    /**
+     * Components to exclude.
+     */
+    exclude?: (ComponentName | LabComponentName)[]
+}
+
+export function VuetifyComposables (options: VuetifyComposablesOptions = {}) {
+    const { prefix } = options
+    const composableImports: [link: string, name: string][] = [
+        ['use-date', 'useDate'],
+        ['use-defaults', 'useDefaults'],
+        ['use-display', 'useDisplay'],
+        ['use-go-to', 'useGoTo'],
+        ['use-layout', 'useLayout'],
+        ['use-locale', 'useLocale'],
+        ['use-rtl', 'useRtl'],
+        ['use-theme', 'useTheme'],
+    ]
+    const imports = typeof prefix === 'string'
+        ? composableImports.map(([l, n]) => [l, n, n.replace('use', `use${prefix}`)])
+        : prefix
+            ? composableImports.map(([l, n]) => [l, n, n.replace('use', 'useV')])
+            : composableImports
+    return {
+        from: 'vuetify',
+        imports: imports.map<PresetImport>(([link, name, renamed]) => ({
+            name: name!,
+            as: renamed,
+            meta: { docsUrl: `https://vuetifyjs.com/en/api/${link}/` },
+        })),
+    } satisfies InlinePreset
+}
+
+export function VuetifyDirectives (options: VuetifyDirectivesOptions = {}) {
+    const { exclude, prefix } = options
+    const directivesImports: [link: string, name: DirectiveName][] = [
+        ['click-outside', 'ClickOutside'],
+        ['intersect', 'Intersect'],
+        ['mutate', 'Mutate'],
+        ['resize', 'Resize'],
+        ['ripple', 'Ripple'],
+        ['scroll', 'Scroll'],
+        ['touch', 'Touch'],
+        ['tooltip', 'Tooltip'],
+    ]
+
+    const directives = directivesImports.filter(entry => !exclude || !exclude.includes(entry[1]))
+
+    return {
+        from: 'vuetify/directives',
+        meta: {
+            vueDirective: true,
+        },
+        imports: directives.map<PresetImport>(([link, name]) => ({
+            name,
+            as: prefix ? `Vuetify${name}` : undefined,
+            meta: {
+                vueDirective: true,
+                docsUrl: `https://vuetifyjs.com/en/api/v-${link}-directive/`,
+            },
+        })),
+    } satisfies InlinePreset
+}
+
+export function buildAddonsOptions (addons?: AddonsOptions | Addon[]): AddonsOptions {
+    if (!addons) {
+        return { vueDirectives: true }
+    }
+
+    if (Array.isArray(addons)) {
+        return { vueDirectives: true, addons }
+    }
+
+    return {
+        ...addons,
+        vueDirectives: addons.vueDirectives ?? true,
+        addons: addons.addons,
+    }
+}
+
+export async function prepareVuetifyComponents (options: VuetifyComponentsOptions = {}) {
+    const { prefix = false, exclude = [] } = options
+    const info: VuetifyComponentInfo[] = []
+    const [components, labs] = await Promise.all(
+        resolveVuetifyImportMaps()
+    )
+
+    const map = new Map<string, VuetifyComponent & { name: string }>()
+    for (const [component, entry] of Object.entries(components.components)) {
+        if (exclude.length > 0 && exclude.includes(component as any)) {
+            continue
+        }
+        map.set(mapComponent(prefix, component), {
+            from: `vuetify/${resolveVuetifyComponentFrom(entry)}`,
+            name: component,
+        })
+    }
+    for (const [component, entry] of Object.entries(labs.components)) {
+        if (exclude.length > 0 && exclude.includes(component as any)) {
+            continue
+        }
+        map.set(mapComponent(prefix, component), {
+            from: `vuetify/${resolveVuetifyComponentFrom(entry)}`,
+            name: component,
+        })
+    }
+
+    for (const [component, entry] of map.entries()) {
+        info.push({
+            pascalName: component,
+            kebabName: toKebabCase(component),
+            export: entry.name,
+            filePath: entry.from,
+        })
+    }
+
+    return info
+}

--- a/packages/unplugin-vuetify/src/unplugin-vue-component-resolvers.ts
+++ b/packages/unplugin-vuetify/src/unplugin-vue-component-resolvers.ts
@@ -1,0 +1,185 @@
+// Types
+import type { ComponentResolver } from 'unplugin-vue-components/types'
+import type {
+    ComponentName,
+    DirectiveName,
+    ImportComponents,
+    ImportMaps,
+    LabComponentName,
+} from './types'
+import {
+    prepareTransformAssetUrls,
+    resolveVuetifyComponentFrom,
+    resolveVuetifyImportMap,
+    resolveVuetifyImportMaps,
+} from './utils'
+
+export type { ComponentName, DirectiveName, LabComponentName }
+
+export interface VuetifyComponentResolverOptions {
+    /**
+     * Prefix Vuetify components (to allow use other components with the same name):
+     * - when prefix set to `true` will use `Vuetify` => `vuetify-<component>/Vuetify<component>: `vuetify-btn/VuetifyBtn`.
+     */
+    prefix?: true
+    /**
+     * Include labs components?.
+     *
+     * @default true
+     */
+    labs?: boolean
+    /**
+     * Components to exclude.
+     */
+    exclude?: (ComponentName | LabComponentName)[]
+    /**
+     * Paths to locate Vuetify package.
+     *
+     * @default [process.cwd()]
+     */
+    paths?: string[]
+}
+
+export interface VuetifyDirectivesResolverOptions {
+    /**
+     * Prefix Vuetify directives (to allow use other directives with the same name):
+     * - when prefix set to `true` will use `Vuetify` => `v-vuetify-<directive>: `v-vuetify-ripple`.
+     */
+    prefix?: true
+    /**
+     * Directives to exclude.
+     */
+    exclude?: DirectiveName[]
+    /**
+     * Paths to locate Vuetify package.
+     *
+     * @default [process.cwd()]
+     */
+    paths?: string[]
+}
+
+export { prepareTransformAssetUrls }
+
+export interface VuetifyVueResolverOptions extends Omit<VuetifyComponentResolverOptions, 'exclude'> {
+    /**
+     * Prefix Vuetify components (to allow use other components with the same name):
+     * - when prefix set to `true` will use `Vuetify` => `vuetify-<component>/Vuetify<component>: `vuetify-btn/VuetifyBtn`.
+     */
+    prefixComponents?: true
+    /**
+     * Prefix Vuetify directives (to allow use other directives with the same name):
+     * - when prefix set to `true` will use `Vuetify` => `v-vuetify-<directive>: `v-vuetify-ripple`.
+     */
+    prefixDirectives?: true
+    /**
+     * Directives to exclude.
+     */
+    excludeDirectives?: DirectiveName[]
+    /**
+     * Components to exclude.
+     */
+    excludeComponents?: (ComponentName | LabComponentName)[]
+}
+
+export function VuetifyVueResolver (options: VuetifyVueResolverOptions = {}) {
+    const {
+        paths,
+        excludeDirectives,
+        labs = true,
+        excludeComponents,
+        prefixComponents,
+        prefixDirectives,
+    } = options
+
+    const [componentsPromise, directivesPromise] = resolveVuetifyImportMaps(paths)
+
+    const directives = createDirectivesResolver(
+        componentsPromise,
+        { exclude: excludeDirectives, paths, prefix: prefixDirectives }
+    )
+    const components = createComponentsResolver(
+        [componentsPromise, directivesPromise],
+        { exclude: excludeComponents, labs, paths, prefix: prefixComponents },
+    )
+
+    return {
+        transformAssetUrls: prepareTransformAssetUrls(prefixComponents === true),
+        VuetifyDirectiveResolver: directives,
+        VuetifyComponentResolver: components,
+    }
+}
+
+export function VuetifyDirectiveResolver (options: VuetifyDirectivesResolverOptions = {}) {
+    return createDirectivesResolver(resolveVuetifyImportMap(options.paths), options)
+}
+
+export function VuetifyComponentResolver (options: VuetifyComponentResolverOptions = {}) {
+    return createComponentsResolver(resolveVuetifyImportMaps(options.paths), options)
+}
+
+function createComponentsResolver (
+    promises: ImportMaps,
+    options: VuetifyComponentResolverOptions
+) {
+    const { exclude, labs, prefix } = options
+    return {
+        type: 'component',
+        resolve: async name => {
+            let vuetifyName = name
+            if (prefix) {
+                if (!name.startsWith('Vuetify')) {
+                    return undefined
+                }
+                vuetifyName = `V${name.slice('Vuetify'.length)}`
+            }
+            if (exclude?.some(e => e === vuetifyName)) return undefined
+            const [components, labsComponents] = await Promise.all(promises)
+            const component = vuetifyName in components.components
+                ? components.components[vuetifyName]
+                : labs && vuetifyName in labsComponents
+                    ? labsComponents[vuetifyName]
+                    : undefined
+
+            if (!component) return undefined
+            return {
+                name: vuetifyName,
+                as: prefix ? name : undefined,
+                type: 'component',
+                from: `vuetify/${resolveVuetifyComponentFrom(component)}`,
+            }
+        },
+    } satisfies ComponentResolver
+}
+
+function createDirectivesResolver (
+    promise: Promise<ImportComponents>,
+    options: VuetifyDirectivesResolverOptions
+) {
+    const { exclude, prefix } = options
+    // Vue will transform v-<directive> to _resolveDirective('<directive>')
+    // If prefix enabled, Vue will transform v-vuetify-<directive> to _resolveDirective('vuetify-<directive>')
+    // unplugin-vue-components will provide the correct import when calling resolve: PascalCase(<directive>)
+    // If prefix enabled, unplugin-vue-components will provide PascalCase(vuetify-<directive>)
+    return {
+        type: 'directive',
+        resolve: async resolvedName => {
+            let name = resolvedName
+            if (prefix) {
+                if (!name.startsWith('Vuetify')) {
+                    return undefined
+                }
+                name = name.slice('Vuetify'.length)
+            }
+            if (exclude?.some(e => e === name)) return undefined
+            const { directives } = await promise
+            const directive = directives.includes(name as DirectiveName)
+            if (!directive) return undefined
+
+            return {
+                name,
+                as: prefix ? resolvedName : undefined,
+                from: `vuetify/directives`,
+            }
+        },
+    } satisfies ComponentResolver
+}

--- a/packages/unplugin-vuetify/src/unplugin-vue-components-resolvers.ts
+++ b/packages/unplugin-vuetify/src/unplugin-vue-components-resolvers.ts
@@ -109,6 +109,15 @@ export function VuetifyVueResolver (options: VuetifyVueResolverOptions = {}) {
     }
 }
 
+/**
+ * Vuetify directives resolver for `unplugin-vue-components`.
+ *
+ * **WARNING**: current version of `unplugin-vue-components` does not configure correctly the directives
+ * and won't work with `Vuetify` directives, use `unplugin-auto-import` with Vuetify directives
+ * preset from `unimport-presets` subpackage export.
+ *
+ * @see https://github.com/unplugin/unplugin-vue-components/pull/828
+ */
 export function VuetifyDirectiveResolver (options: VuetifyDirectivesResolverOptions = {}) {
     return createDirectivesResolver(resolveVuetifyImportMap(options.paths), options)
 }

--- a/packages/unplugin-vuetify/src/utils.ts
+++ b/packages/unplugin-vuetify/src/utils.ts
@@ -41,12 +41,13 @@ export function prepareTransformAssetUrls (prefix: boolean) {
 
     if (!prefix) {
         for (const [component, attrs] of Object.entries(transformAssetUrls)) {
+            const useAttrs = [...attrs]
             for (const attr of attrs) {
                 if (/[A-Z]/.test(attr)) {
-                    attrs.push(toKebabCase(attr))
+                    useAttrs.push(toKebabCase(attr))
                 }
             }
-            transformAssetUrls[toKebabCase(component)] = attrs
+            transformAssetUrls[toKebabCase(component)] = useAttrs
         }
 
         return transformAssetUrls
@@ -55,13 +56,14 @@ export function prepareTransformAssetUrls (prefix: boolean) {
     const result: Record<string, string[]> = {}
     for (const [component, attrs] of Object.entries(transformAssetUrls)) {
         const useComponent = mapComponent(true, component)
-        result[useComponent] = attrs
+        const useAttrs = [...attrs]
+        result[useComponent] = useAttrs
         for (const attr of attrs) {
             if (/[A-Z]/.test(attr)) {
-                attrs.push(toKebabCase(attr))
+                useAttrs.push(toKebabCase(attr))
             }
         }
-        result[toKebabCase(useComponent)] = attrs
+        result[toKebabCase(useComponent)] = useAttrs
     }
 
     return result

--- a/packages/unplugin-vuetify/src/utils.ts
+++ b/packages/unplugin-vuetify/src/utils.ts
@@ -1,0 +1,95 @@
+import { readFile } from 'node:fs/promises'
+import path from 'upath'
+import { createRequire } from 'node:module'
+import process from 'node:process'
+
+// Types
+import type { ImportComponents, ImportLabsComponents, ImportMaps, VuetifyComponent } from './types'
+
+const require = createRequire(import.meta.url)
+
+export function resolveVuetifyBase (paths = [process.cwd()]) {
+    return path.dirname(require.resolve('vuetify/package.json', { paths }))
+}
+
+export function toKebabCase (str: string) {
+    return str
+        .replace(/[^a-z]/gi, '-')
+        .replace(/\B([A-Z])/g, '-$1')
+        .toLowerCase()
+}
+
+export function mapComponent (prefix: boolean, name: string) {
+    return prefix ? name.replace(/^V/, 'Vuetify') : name
+}
+
+export function prepareTransformAssetUrls (prefix: boolean) {
+    const transformAssetUrls = {
+        VAppBar: ['image'],
+        VAvatar: ['image'],
+        VBanner: ['avatar'],
+        VCard: ['image', 'prependAvatar', 'appendAvatar'],
+        VCardItem: ['prependAvatar', 'appendAvatar'],
+        VCarouselItem: ['src', 'lazySrc', 'srcset'],
+        VChip: ['prependAvatar', 'appendAvatar'],
+        VImg: ['src', 'lazySrc', 'srcset'],
+        VListItem: ['prependAvatar', 'appendAvatar'],
+        VNavigationDrawer: ['image'],
+        VParallax: ['src', 'lazySrc', 'srcset'],
+        VToolbar: ['image'],
+    } as Record<string, string[]>
+
+    if (!prefix) {
+        for (const [component, attrs] of Object.entries(transformAssetUrls)) {
+            for (const attr of attrs) {
+                if (/[A-Z]/.test(attr)) {
+                    attrs.push(toKebabCase(attr))
+                }
+            }
+            transformAssetUrls[toKebabCase(component)] = attrs
+        }
+
+        return transformAssetUrls
+    }
+
+    const result: Record<string, string[]> = {}
+    for (const [component, attrs] of Object.entries(transformAssetUrls)) {
+        const useComponent = mapComponent(true, component)
+        result[useComponent] = attrs
+        for (const attr of attrs) {
+            if (/[A-Z]/.test(attr)) {
+                attrs.push(toKebabCase(attr))
+            }
+        }
+        result[toKebabCase(useComponent)] = attrs
+    }
+
+    return result
+}
+
+export function resolveVuetifyImportMaps (
+    paths = [process.cwd()]
+): ImportMaps {
+    const vuetifyBase = resolveVuetifyBase(paths)
+    return [importMap(vuetifyBase), importMapLabs(vuetifyBase)]
+}
+
+export function resolveVuetifyImportMap (paths = [process.cwd()]) {
+    return importMap(resolveVuetifyBase(paths))
+}
+
+export function resolveVuetifyImportMapLabs (paths = [process.cwd()]) {
+    return importMapLabs(resolveVuetifyBase(paths))
+}
+
+// Vuetify 3.7.11+ resolves to subpath exports instead of a file in /lib
+export function resolveVuetifyComponentFrom ({ from }: VuetifyComponent) {
+    return from.endsWith('.mjs') ? `lib/${from}` : from
+}
+
+async function importMap (vuetifyBase: string): Promise<ImportComponents> {
+    return JSON.parse(await readFile(path.resolve(vuetifyBase, 'dist/json/importMap.json'), 'utf-8'))
+}
+async function importMapLabs (vuetifyBase: string): Promise<ImportLabsComponents> {
+    return JSON.parse(await readFile(path.resolve(vuetifyBase, 'dist/json/importMap-labs.json'), 'utf-8'))
+}

--- a/packages/unplugin-vuetify/tsconfig.json
+++ b/packages/unplugin-vuetify/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -958,6 +958,11 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.3.tgz#90420f9f9c6d3987f176a19a7d8e764271a2f55d"
   integrity sha512-Fxt+AfXgjMoin2maPIYzFZnQjAXjAL0PHscM5pRTtatFqB+vZxAM9tLp2Optnuw3QOQC40jTNeGYFOMvyf7v9g==
 
+"@esbuild/aix-ppc64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz#c7184a326533fcdf1b8ee0733e21c713b975575f"
+  integrity sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==
+
 "@esbuild/aix-ppc64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.2.tgz#b87036f644f572efb2b3c75746c97d1d2d87ace8"
@@ -967,6 +972,11 @@
   version "0.19.8"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.19.8.tgz#fb7130103835b6d43ea499c3f30cfb2b2ed58456"
   integrity sha512-B8JbS61bEunhfx8kasogFENgQfr/dIp+ggYXwTqdbMAgGDhRa3AaPpQMuQU0rNxDLECj6FhDzk1cF9WHMVwrtA==
+
+"@esbuild/android-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz#09d9b4357780da9ea3a7dfb833a1f1ff439b4052"
+  integrity sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==
 
 "@esbuild/android-arm64@0.25.2":
   version "0.25.2"
@@ -978,6 +988,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.19.8.tgz#b46e4d9e984e6d6db6c4224d72c86b7757e35bcb"
   integrity sha512-31E2lxlGM1KEfivQl8Yf5aYU/mflz9g06H6S15ITUFQueMFtFjESRMoDSkvMo8thYvLBax+VKTPlpnx+sPicOA==
 
+"@esbuild/android-arm@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.21.5.tgz#9b04384fb771926dfa6d7ad04324ecb2ab9b2e28"
+  integrity sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==
+
 "@esbuild/android-arm@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.25.2.tgz#3c49f607b7082cde70c6ce0c011c362c57a194ee"
@@ -987,6 +1002,11 @@
   version "0.19.8"
   resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.19.8.tgz#a13db9441b5a4f4e4fec4a6f8ffacfea07888db7"
   integrity sha512-rdqqYfRIn4jWOp+lzQttYMa2Xar3OK9Yt2fhOhzFXqg0rVWEfSclJvZq5fZslnz6ypHvVf3CT7qyf0A5pM682A==
+
+"@esbuild/android-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.21.5.tgz#29918ec2db754cedcb6c1b04de8cd6547af6461e"
+  integrity sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==
 
 "@esbuild/android-x64@0.25.2":
   version "0.25.2"
@@ -998,6 +1018,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.19.8.tgz#49f5718d36541f40dd62bfdf84da9c65168a0fc2"
   integrity sha512-RQw9DemMbIq35Bprbboyf8SmOr4UXsRVxJ97LgB55VKKeJOOdvsIPy0nFyF2l8U+h4PtBx/1kRf0BelOYCiQcw==
 
+"@esbuild/darwin-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz#e495b539660e51690f3928af50a76fb0a6ccff2a"
+  integrity sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==
+
 "@esbuild/darwin-arm64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.2.tgz#486efe7599a8d90a27780f2bb0318d9a85c6c423"
@@ -1007,6 +1032,11 @@
   version "0.19.8"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.19.8.tgz#75c5c88371eea4bfc1f9ecfd0e75104c74a481ac"
   integrity sha512-3sur80OT9YdeZwIVgERAysAbwncom7b4bCI2XKLjMfPymTud7e/oY4y+ci1XVp5TfQp/bppn7xLw1n/oSQY3/Q==
+
+"@esbuild/darwin-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz#c13838fa57372839abdddc91d71542ceea2e1e22"
+  integrity sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==
 
 "@esbuild/darwin-x64@0.25.2":
   version "0.25.2"
@@ -1018,6 +1048,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.8.tgz#9d7259fea4fd2b5f7437b52b542816e89d7c8575"
   integrity sha512-WAnPJSDattvS/XtPCTj1tPoTxERjcTpH6HsMr6ujTT+X6rylVe8ggxk8pVxzf5U1wh5sPODpawNicF5ta/9Tmw==
 
+"@esbuild/freebsd-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz#646b989aa20bf89fd071dd5dbfad69a3542e550e"
+  integrity sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==
+
 "@esbuild/freebsd-arm64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.2.tgz#67efceda8554b6fc6a43476feba068fb37fa2ef6"
@@ -1027,6 +1062,11 @@
   version "0.19.8"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.19.8.tgz#abac03e1c4c7c75ee8add6d76ec592f46dbb39e3"
   integrity sha512-ICvZyOplIjmmhjd6mxi+zxSdpPTKFfyPPQMQTK/w+8eNK6WV01AjIztJALDtwNNfFhfZLux0tZLC+U9nSyA5Zg==
+
+"@esbuild/freebsd-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz#aa615cfc80af954d3458906e38ca22c18cf5c261"
+  integrity sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==
 
 "@esbuild/freebsd-x64@0.25.2":
   version "0.25.2"
@@ -1038,6 +1078,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.19.8.tgz#c577932cf4feeaa43cb9cec27b89cbe0df7d9098"
   integrity sha512-z1zMZivxDLHWnyGOctT9JP70h0beY54xDDDJt4VpTX+iwA77IFsE1vCXWmprajJGa+ZYSqkSbRQ4eyLCpCmiCQ==
 
+"@esbuild/linux-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz#70ac6fa14f5cb7e1f7f887bcffb680ad09922b5b"
+  integrity sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==
+
 "@esbuild/linux-arm64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.25.2.tgz#87be1099b2bbe61282333b084737d46bc8308058"
@@ -1047,6 +1092,11 @@
   version "0.19.8"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.19.8.tgz#d6014d8b98b5cbc96b95dad3d14d75bb364fdc0f"
   integrity sha512-H4vmI5PYqSvosPaTJuEppU9oz1dq2A7Mr2vyg5TF9Ga+3+MGgBdGzcyBP7qK9MrwFQZlvNyJrvz6GuCaj3OukQ==
+
+"@esbuild/linux-arm@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz#fc6fd11a8aca56c1f6f3894f2bea0479f8f626b9"
+  integrity sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==
 
 "@esbuild/linux-arm@0.25.2":
   version "0.25.2"
@@ -1058,6 +1108,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.19.8.tgz#2379a0554307d19ac4a6cdc15b08f0ea28e7a40d"
   integrity sha512-1a8suQiFJmZz1khm/rDglOc8lavtzEMRo0v6WhPgxkrjcU0LkHj+TwBrALwoz/OtMExvsqbbMI0ChyelKabSvQ==
 
+"@esbuild/linux-ia32@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz#3271f53b3f93e3d093d518d1649d6d68d346ede2"
+  integrity sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==
+
 "@esbuild/linux-ia32@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.25.2.tgz#337a87a4c4dd48a832baed5cbb022be20809d737"
@@ -1067,6 +1122,11 @@
   version "0.19.8"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.19.8.tgz#e2a5bbffe15748b49356a6cd7b2d5bf60c5a7123"
   integrity sha512-fHZWS2JJxnXt1uYJsDv9+b60WCc2RlvVAy1F76qOLtXRO+H4mjt3Tr6MJ5l7Q78X8KgCFudnTuiQRBhULUyBKQ==
+
+"@esbuild/linux-loong64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz#ed62e04238c57026aea831c5a130b73c0f9f26df"
+  integrity sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==
 
 "@esbuild/linux-loong64@0.25.2":
   version "0.25.2"
@@ -1078,6 +1138,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.19.8.tgz#1359331e6f6214f26f4b08db9b9df661c57cfa24"
   integrity sha512-Wy/z0EL5qZYLX66dVnEg9riiwls5IYnziwuju2oUiuxVc+/edvqXa04qNtbrs0Ukatg5HEzqT94Zs7J207dN5Q==
 
+"@esbuild/linux-mips64el@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz#e79b8eb48bf3b106fadec1ac8240fb97b4e64cbe"
+  integrity sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==
+
 "@esbuild/linux-mips64el@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.2.tgz#afbe380b6992e7459bf7c2c3b9556633b2e47f30"
@@ -1087,6 +1152,11 @@
   version "0.19.8"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.19.8.tgz#9ba436addc1646dc89dae48c62d3e951ffe70951"
   integrity sha512-ETaW6245wK23YIEufhMQ3HSeHO7NgsLx8gygBVldRHKhOlD1oNeNy/P67mIh1zPn2Hr2HLieQrt6tWrVwuqrxg==
+
+"@esbuild/linux-ppc64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz#5f2203860a143b9919d383ef7573521fb154c3e4"
+  integrity sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==
 
 "@esbuild/linux-ppc64@0.25.2":
   version "0.25.2"
@@ -1098,6 +1168,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.19.8.tgz#fbcf0c3a0b20f40b5fc31c3b7695f0769f9de66b"
   integrity sha512-T2DRQk55SgoleTP+DtPlMrxi/5r9AeFgkhkZ/B0ap99zmxtxdOixOMI570VjdRCs9pE4Wdkz7JYrsPvsl7eESg==
 
+"@esbuild/linux-riscv64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz#07bcafd99322d5af62f618cb9e6a9b7f4bb825dc"
+  integrity sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==
+
 "@esbuild/linux-riscv64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.2.tgz#43c2d67a1a39199fb06ba978aebb44992d7becc3"
@@ -1108,6 +1183,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.19.8.tgz#989e8a05f7792d139d5564ffa7ff898ac6f20a4a"
   integrity sha512-NPxbdmmo3Bk7mbNeHmcCd7R7fptJaczPYBaELk6NcXxy7HLNyWwCyDJ/Xx+/YcNH7Im5dHdx9gZ5xIwyliQCbg==
 
+"@esbuild/linux-s390x@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz#b7ccf686751d6a3e44b8627ababc8be3ef62d8de"
+  integrity sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==
+
 "@esbuild/linux-s390x@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.2.tgz#419e25737ec815c6dce2cd20d026e347cbb7a602"
@@ -1117,6 +1197,11 @@
   version "0.19.8"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.19.8.tgz#b187295393a59323397fe5ff51e769ec4e72212b"
   integrity sha512-lytMAVOM3b1gPypL2TRmZ5rnXl7+6IIk8uB3eLsV1JwcizuolblXRrc5ShPrO9ls/b+RTp+E6gbsuLWHWi2zGg==
+
+"@esbuild/linux-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz#6d8f0c768e070e64309af8004bb94e68ab2bb3b0"
+  integrity sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==
 
 "@esbuild/linux-x64@0.25.2":
   version "0.25.2"
@@ -1133,6 +1218,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.19.8.tgz#c1ec0e24ea82313cb1c7bae176bd5acd5bde7137"
   integrity sha512-hvWVo2VsXz/8NVt1UhLzxwAfo5sioj92uo0bCfLibB0xlOmimU/DeAEsQILlBQvkhrGjamP0/el5HU76HAitGw==
 
+"@esbuild/netbsd-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz#bbe430f60d378ecb88decb219c602667387a6047"
+  integrity sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==
+
 "@esbuild/netbsd-x64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.2.tgz#dbbe7521fd6d7352f34328d676af923fc0f8a78f"
@@ -1148,6 +1238,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.19.8.tgz#0c5b696ac66c6d70cf9ee17073a581a28af9e18d"
   integrity sha512-/7Y7u77rdvmGTxR83PgaSvSBJCC2L3Kb1M/+dmSIvRvQPXXCuC97QAwMugBNG0yGcbEGfFBH7ojPzAOxfGNkwQ==
 
+"@esbuild/openbsd-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz#99d1cf2937279560d2104821f5ccce220cb2af70"
+  integrity sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==
+
 "@esbuild/openbsd-x64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.2.tgz#d2bb6a0f8ffea7b394bb43dfccbb07cabd89f768"
@@ -1157,6 +1252,11 @@
   version "0.19.8"
   resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.19.8.tgz#2a697e1f77926ff09fcc457d8f29916d6cd48fb1"
   integrity sha512-9Lc4s7Oi98GqFA4HzA/W2JHIYfnXbUYgekUP/Sm4BG9sfLjyv6GKKHKKVs83SMicBF2JwAX6A1PuOLMqpD001w==
+
+"@esbuild/sunos-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz#08741512c10d529566baba837b4fe052c8f3487b"
+  integrity sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==
 
 "@esbuild/sunos-x64@0.25.2":
   version "0.25.2"
@@ -1168,6 +1268,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.19.8.tgz#ec029e62a2fca8c071842ecb1bc5c2dd20b066f1"
   integrity sha512-rq6WzBGjSzihI9deW3fC2Gqiak68+b7qo5/3kmB6Gvbh/NYPA0sJhrnp7wgV4bNwjqM+R2AApXGxMO7ZoGhIJg==
 
+"@esbuild/win32-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz#675b7385398411240735016144ab2e99a60fc75d"
+  integrity sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==
+
 "@esbuild/win32-arm64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.2.tgz#081424168463c7d6c7fb78f631aede0c104373cf"
@@ -1178,6 +1283,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.19.8.tgz#cbb9a3146bde64dc15543e48afe418c7a3214851"
   integrity sha512-AIAbverbg5jMvJznYiGhrd3sumfwWs8572mIJL5NQjJa06P8KfCPWZQ0NwZbPQnbQi9OWSZhFVSUWjjIrn4hSw==
 
+"@esbuild/win32-ia32@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz#1bfc3ce98aa6ca9a0969e4d2af72144c59c1193b"
+  integrity sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==
+
 "@esbuild/win32-ia32@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.25.2.tgz#3f9e87143ddd003133d21384944a6c6cadf9693f"
@@ -1187,6 +1297,11 @@
   version "0.19.8"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.19.8.tgz#c8285183dbdb17008578dbacb6e22748709b4822"
   integrity sha512-bfZ0cQ1uZs2PqpulNL5j/3w+GDhP36k1K5c38QdQg+Swy51jFZWWeIkteNsufkQxp986wnqRRsb/bHbY1WQ7TA==
+
+"@esbuild/win32-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz#acad351d582d157bb145535db2a6ff53dd514b5c"
+  integrity sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==
 
 "@esbuild/win32-x64@0.25.2":
   version "0.25.2"
@@ -2983,6 +3098,11 @@ acorn@^8.10.0, acorn@^8.7.1, acorn@^8.8.2:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.2.tgz#ca0d78b51895be5390a5903c5b3bdcdaf78ae40b"
   integrity sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==
 
+acorn@^8.14.0, acorn@^8.14.1:
+  version "8.14.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.1.tgz#721d5dc10f7d5b5609a891773d47731796935dfb"
+  integrity sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==
+
 agent-base@4, agent-base@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
@@ -3699,6 +3819,21 @@ chardet@^0.7.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
+chokidar@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
+  integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 chownr@^1.1.1, chownr@^1.1.2, chownr@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
@@ -3919,6 +4054,16 @@ concat-stream@^2.0.0:
     inherits "^2.0.3"
     readable-stream "^3.0.2"
     typedarray "^0.0.6"
+
+confbox@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/confbox/-/confbox-0.1.8.tgz#820d73d3b3c82d9bd910652c5d4d599ef8ff8b06"
+  integrity sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==
+
+confbox@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/confbox/-/confbox-0.2.2.tgz#8652f53961c74d9e081784beed78555974a9c110"
+  integrity sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==
 
 config-chain@^1.1.11:
   version "1.1.13"
@@ -4303,6 +4448,13 @@ debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
+
+debug@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.0.tgz#2b3f2aea2ffeb776477460267377dc8710faba8a"
+  integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
+  dependencies:
+    ms "^2.1.3"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -4760,6 +4912,35 @@ esbuild@^0.19.2, esbuild@^0.19.7:
     "@esbuild/win32-ia32" "0.19.8"
     "@esbuild/win32-x64" "0.19.8"
 
+esbuild@^0.21.3:
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.21.5.tgz#9ca301b120922959b766360d8ac830da0d02997d"
+  integrity sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.21.5"
+    "@esbuild/android-arm" "0.21.5"
+    "@esbuild/android-arm64" "0.21.5"
+    "@esbuild/android-x64" "0.21.5"
+    "@esbuild/darwin-arm64" "0.21.5"
+    "@esbuild/darwin-x64" "0.21.5"
+    "@esbuild/freebsd-arm64" "0.21.5"
+    "@esbuild/freebsd-x64" "0.21.5"
+    "@esbuild/linux-arm" "0.21.5"
+    "@esbuild/linux-arm64" "0.21.5"
+    "@esbuild/linux-ia32" "0.21.5"
+    "@esbuild/linux-loong64" "0.21.5"
+    "@esbuild/linux-mips64el" "0.21.5"
+    "@esbuild/linux-ppc64" "0.21.5"
+    "@esbuild/linux-riscv64" "0.21.5"
+    "@esbuild/linux-s390x" "0.21.5"
+    "@esbuild/linux-x64" "0.21.5"
+    "@esbuild/netbsd-x64" "0.21.5"
+    "@esbuild/openbsd-x64" "0.21.5"
+    "@esbuild/sunos-x64" "0.21.5"
+    "@esbuild/win32-arm64" "0.21.5"
+    "@esbuild/win32-ia32" "0.21.5"
+    "@esbuild/win32-x64" "0.21.5"
+
 esbuild@^0.25.0:
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.25.2.tgz#55a1d9ebcb3aa2f95e8bba9e900c1a5061bc168b"
@@ -4810,6 +4991,11 @@ escape-string-regexp@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
+escape-string-regexp@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
+  integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
 
 eslint-import-resolver-node@^0.3.6:
   version "0.3.6"
@@ -4963,6 +5149,13 @@ estree-walker@^2.0.2:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
+estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -5081,6 +5274,11 @@ express@^4.17.3:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+exsolve@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/exsolve/-/exsolve-1.0.4.tgz#7de5c75af82ecd15998328fbf5f2295883be3a39"
+  integrity sha512-xsZH6PXaER4XoV+NiT7JHp1bJodJVT+cxeSH1G0f0tlT0lJqYuHUP3bUx2HtfTDvOagMINYp8rsqusxud3RXhw==
+
 extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
@@ -5190,6 +5388,11 @@ faye-websocket@^0.11.3:
   integrity sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==
   dependencies:
     websocket-driver ">=0.5.1"
+
+fdir@^6.4.3:
+  version "6.4.3"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.3.tgz#011cdacf837eca9b811c89dbb902df714273db72"
+  integrity sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==
 
 figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
   version "3.5.2"
@@ -6565,6 +6768,11 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
+js-tokens@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-9.0.1.tgz#2ec43964658435296f6761b34e10671c2d9527f4"
+  integrity sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==
+
 js-yaml@^3.13.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
@@ -6815,6 +7023,15 @@ loader-utils@^2.0.0:
     emojis-list "^3.0.0"
     json5 "^2.1.2"
 
+local-pkg@^1.0.0, local-pkg@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-1.1.1.tgz#f5fe74a97a3bd3c165788ee08ca9fbe998dc58dd"
+  integrity sha512-WunYko2W1NcdfAFpuLUoucsgULmgDBRkdxHxWQ7mK0cQqwPiy8E1enjuRBrhLtZkB5iScJ1XIPdhVEFK8aOLSg==
+  dependencies:
+    mlly "^1.7.4"
+    pkg-types "^2.0.1"
+    quansync "^0.2.8"
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -6942,7 +7159,7 @@ macos-release@^2.2.0:
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.5.0.tgz#067c2c88b5f3fb3c56a375b2ec93826220fa1ff2"
   integrity sha512-EIgv+QZ9r+814gjJj0Bt5vSLJLzswGmSUbUpbi9AIr/fsN2IWFBl2NucV9PAiek+U1STK468tEkxmVYUtuAN3g==
 
-magic-string@^0.30.11, magic-string@^0.30.3, magic-string@^0.30.4:
+magic-string@^0.30.11, magic-string@^0.30.17, magic-string@^0.30.3, magic-string@^0.30.4:
   version "0.30.17"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.17.tgz#450a449673d2460e5bbcfba9a61916a1714c7453"
   integrity sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==
@@ -7290,6 +7507,16 @@ mlly@^1.2.0, mlly@^1.4.0, mlly@^1.4.2:
     pkg-types "^1.0.3"
     ufo "^1.3.0"
 
+mlly@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/mlly/-/mlly-1.7.4.tgz#3d7295ea2358ec7a271eaa5d000a0f84febe100f"
+  integrity sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==
+  dependencies:
+    acorn "^8.14.0"
+    pathe "^2.0.1"
+    pkg-types "^1.3.0"
+    ufo "^1.5.4"
+
 modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
@@ -7327,7 +7554,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
+ms@2.1.3, ms@^2.0.0, ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -8040,6 +8267,11 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pathe@2.0.3, pathe@^2.0.1, pathe@^2.0.2, pathe@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
+  integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
+
 pathe@^1.1.0, pathe@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.1.tgz#1dd31d382b974ba69809adc9a7a347e65d84829a"
@@ -8059,6 +8291,11 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+picomatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
+  integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
@@ -8116,6 +8353,24 @@ pkg-types@^1.0.3:
     jsonc-parser "^3.2.0"
     mlly "^1.2.0"
     pathe "^1.1.0"
+
+pkg-types@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/pkg-types/-/pkg-types-1.3.1.tgz#bd7cc70881192777eef5326c19deb46e890917df"
+  integrity sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==
+  dependencies:
+    confbox "^0.1.8"
+    mlly "^1.7.4"
+    pathe "^2.0.1"
+
+pkg-types@^2.0.1, pkg-types@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/pkg-types/-/pkg-types-2.1.0.tgz#70c9e1b9c74b63fdde749876ee0aa007ea9edead"
+  integrity sha512-wmJwA+8ihJixSoHKxZJRBQG1oY8Yr9pGLzRmSsNms0iNWyHHAlZCa7mmKiFR10YPZuz/2k169JiS/inOjBCZ2A==
+  dependencies:
+    confbox "^0.2.1"
+    exsolve "^1.0.1"
+    pathe "^2.0.3"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -8366,7 +8621,7 @@ postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.4.21, postcss@^8.4.26, postcss@^8.4.48, postcss@^8.5.3:
+postcss@^8.4.21, postcss@^8.4.26, postcss@^8.4.43, postcss@^8.4.48, postcss@^8.5.3:
   version "8.5.3"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.3.tgz#1463b6f1c7fb16fe258736cba29a2de35237eafb"
   integrity sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==
@@ -8603,6 +8858,11 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+quansync@^0.2.8:
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/quansync/-/quansync-0.2.10.tgz#32053cf166fa36511aae95fc49796116f2dc20e1"
+  integrity sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==
 
 query-string@^6.13.8:
   version "6.14.1"
@@ -9046,7 +9306,7 @@ rollup@^3.28.1:
   optionalDependencies:
     fsevents "~2.3.2"
 
-rollup@^4.30.1:
+rollup@^4.20.0, rollup@^4.30.1:
   version "4.39.0"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.39.0.tgz#9dc1013b70c0e2cb70ef28350142e9b81b3f640c"
   integrity sha512-thI8kNc02yNvnmJp8dr3fNWJ9tCONDhp6TV35X6HkKGGs9E6q7YWCHbe5vKiTa7TAiNcFEmXKj3X/pG2b3ci0g==
@@ -9169,6 +9429,11 @@ scule@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/scule/-/scule-1.1.1.tgz#82b4d13bb8c729c15849256e749cee0cb52a4d89"
   integrity sha512-sHtm/SsIK9BUBI3EFT/Gnp9VoKfY6QLvlkvAE6YK7454IF8FSgJEAnJpVdSC7K5/pjI5NfxhzBLW2JAfYA/shQ==
+
+scule@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/scule/-/scule-1.3.0.tgz#6efbd22fd0bb801bdcc585c89266a7d2daa8fbd3"
+  integrity sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==
 
 select-hose@^2.0.0:
   version "2.0.0"
@@ -9755,6 +10020,13 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+strip-literal@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-literal/-/strip-literal-3.0.0.tgz#ce9c452a91a0af2876ed1ae4e583539a353df3fc"
+  integrity sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==
+  dependencies:
+    js-tokens "^9.0.1"
+
 strong-log-transformer@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz#0f5ed78d325e0421ac6f90f7f10e691d6ae3ae10"
@@ -9923,6 +10195,14 @@ thunky@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
+
+tinyglobby@^0.2.12:
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.12.tgz#ac941a42e0c5773bd0b5d08f32de82e74a1a61b5"
+  integrity sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==
+  dependencies:
+    fdir "^6.4.3"
+    picomatch "^4.0.2"
 
 titleize@^3.0.0:
   version "3.0.0"
@@ -10105,6 +10385,11 @@ ufo@^1.3.0:
   resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.3.2.tgz#c7d719d0628a1c80c006d2240e0d169f6e3c0496"
   integrity sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==
 
+ufo@^1.5.4:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.6.1.tgz#ac2db1d54614d1b22c1d603e3aef44a85d8f146b"
+  integrity sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==
+
 uglify-js@^3.1.4:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.14.1.tgz#e2cb9fe34db9cb4cf7e35d1d26dfea28e09a7d06"
@@ -10188,6 +10473,26 @@ unicode-property-aliases-ecmascript@^2.0.0:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz#43d41e3be698bd493ef911077c9b131f827e8ccd"
   integrity sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==
 
+unimport@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/unimport/-/unimport-5.0.0.tgz#c2e5a364c03fc90de192d8881384a379cf8b4d99"
+  integrity sha512-8jL3T+FKDg+qLFX55X9j92uFRqH5vWrNlf/eJb5IQlQB5q5wjooXQDXP1ulhJJQHbosBmlKhBo/ZVS5jHlcJGA==
+  dependencies:
+    acorn "^8.14.1"
+    escape-string-regexp "^5.0.0"
+    estree-walker "^3.0.3"
+    local-pkg "^1.1.1"
+    magic-string "^0.30.17"
+    mlly "^1.7.4"
+    pathe "^2.0.3"
+    picomatch "^4.0.2"
+    pkg-types "^2.1.0"
+    scule "^1.3.0"
+    strip-literal "^3.0.0"
+    tinyglobby "^0.2.12"
+    unplugin "^2.2.2"
+    unplugin-utils "^0.2.4"
+
 union-value@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847"
@@ -10238,6 +10543,37 @@ unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
+
+unplugin-utils@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/unplugin-utils/-/unplugin-utils-0.2.4.tgz#56e4029a6906645a10644f8befc404b06d5d24d0"
+  integrity sha512-8U/MtpkPkkk3Atewj1+RcKIjb5WBimZ/WSLhhR3w6SsIj8XJuKTacSP8g+2JhfSGw0Cb125Y+2zA/IzJZDVbhA==
+  dependencies:
+    pathe "^2.0.2"
+    picomatch "^4.0.2"
+
+unplugin-vue-components@^28.4.1:
+  version "28.4.1"
+  resolved "https://registry.yarnpkg.com/unplugin-vue-components/-/unplugin-vue-components-28.4.1.tgz#9d6d9555bbe98ea41d673b886e1e638f36200501"
+  integrity sha512-niGSc0vJD9ueAnsqcfAldmtpkppZ09B6p2G1dL7X5S8KPdgbk1P+txPwaaDCe7N+eZh2VG1aAypLXkuJs3OSUg==
+  dependencies:
+    chokidar "^3.6.0"
+    debug "^4.4.0"
+    local-pkg "^1.0.0"
+    magic-string "^0.30.17"
+    mlly "^1.7.4"
+    tinyglobby "^0.2.12"
+    unplugin "^2.2.0"
+    unplugin-utils "^0.2.4"
+
+unplugin@^2.2.0, unplugin@^2.2.2:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/unplugin/-/unplugin-2.3.0.tgz#90c304962a5840625cbf1f2e7384931624008a78"
+  integrity sha512-zNTDfbzOZzkbgXvH1QgQFW5nAyvjA0q3q9FGPFx2sKpDnaoU09VP1wT1mE+LYa6EF2rfezfd1y2EPLLR8ka6nw==
+  dependencies:
+    acorn "^8.14.1"
+    picomatch "^4.0.2"
+    webpack-virtual-modules "^0.6.2"
 
 unset-value@^1.0.0:
   version "1.0.0"
@@ -10383,6 +10719,26 @@ vite-plugin-inspect@^0.8.1:
     open "^9.1.0"
     picocolors "^1.0.0"
     sirv "^2.0.3"
+
+vite-plugin-vuetify@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/vite-plugin-vuetify/-/vite-plugin-vuetify-2.1.0.tgz#56767be099fd18a44ec2f9831d49269722e0e538"
+  integrity sha512-4wEAQtZaigPpwbFcZbrKpYwutOsWwWdeXn22B9XHzDPQNxVsKT+K9lKcXZnI5JESO1Iaql48S9rOk8RZZEt+Mw==
+  dependencies:
+    "@vuetify/loader-shared" "^2.1.0"
+    debug "^4.3.3"
+    upath "^2.0.1"
+
+vite@^5.0.0:
+  version "5.4.18"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-5.4.18.tgz#b5af357f9d5ebb2e0c085779b7a37a77f09168a4"
+  integrity sha512-1oDcnEp3lVyHCuQ2YFelM4Alm2o91xNoMncRm1U7S+JdYfYOvbiGZ3/CxGttrOu2M/KcGz7cRC2DoNUA6urmMA==
+  dependencies:
+    esbuild "^0.21.3"
+    postcss "^8.4.43"
+    rollup "^4.20.0"
+  optionalDependencies:
+    fsevents "~2.3.3"
 
 vite@^6.2.4:
   version "6.2.4"
@@ -10534,10 +10890,29 @@ webpack-merge@^5.7.3:
     clone-deep "^4.0.1"
     wildcard "^2.0.0"
 
+webpack-plugin-vuetify@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/webpack-plugin-vuetify/-/webpack-plugin-vuetify-3.1.0.tgz#322509f205aa1cd9fde9d2f65b703f8a67270006"
+  integrity sha512-+JCZSVA8E/HyGByLA0B1Byg3hSnStFatiBdxKvVpW6hXZR0VaOVIC9m1ZLICThA32sICf87DdRnMPBts4xSlfQ==
+  dependencies:
+    "@vuetify/loader-shared" "^2.1.0"
+    decache "^4.6.0"
+    file-loader "^6.2.0"
+    find-cache-dir "^5.0.0"
+    loader-utils "^2.0.0"
+    mkdirp "^1.0.4"
+    null-loader "^4.0.1"
+    upath "^2.0.1"
+
 webpack-sources@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
+
+webpack-virtual-modules@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz#057faa9065c8acf48f24cb57ac0e77739ab9a7e8"
+  integrity sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==
 
 webpack@^5.89.0:
   version "5.89.0"


### PR DESCRIPTION
This PR on draft, we need to add readme.md files, add another playground and prepare docs at Vuetify:
- includes changes in this Vuetify PR: https://github.com/vuetifyjs/vuetify/pull/21129
- changed the vuetify styles plugin options: now it also allows to register SASS/SCSS api
- package is ESM-only
- webpack support droped: consumers still using webpack will need to use older packages (`unimport` presets and `unplugin-vue-component` resolvers can still be used registering the Vite/Webpack plugin disabling `auto-import`, I've only tested this using Vite)

This package is a modern refactor for existing codebase, doesn't replace/deprecate existing ones.

As summary (to prepare Vuetify docs later and the readme file here):
- don't use Vite plugin directly to auto-import Vuetify components (three-shaking), will use instead the `unimport` presets or the `unplugin-vue-components` resolvers
- exports `unimport` presets to allow (`unimport-presets` subpackage export):
  - use  [Vue Lazy Hydration](https://blog.vuejs.org/posts/vue-3-5#lazy-hydration) with [Nuxt](https://nuxt.com/blog/v3-16#%EF%B8%8F-delayed-hydration-support): LazyVBtn for example when visible
  - using custom prefix for Vuetify components (`VuetifyXXX` instead `VXXX`), directives (`v-vuetify-xxx` instead `v-xxxx`) and composables (`useVXXX` or custom `prefix`) to avoid collisions (disabled by default)
  -  exports utilities to change Vuetify `transformAssetUrls` when enabling custom Vuetify components prefix (check details below)
  - with the directives preset VSCode will suggest Vuetify directives: right now only JetBrains IDE suggesting directives via `webtypes` (I'm talking with Jan-Niklas at JetBrains (WebStorm) to drop support and use Volar instead, now directives names can use `vuetify` prefix => maybe we can also add the entries with the prefix)
- exports `unplugin-vue-component` resolvers to allow (`unplugin-vue-component-resolvers` subpackage export, we need to change the name, missing `s` in the `component`) for:
  - Vuetify components with prefix support similar to previous described at `unimport` presets
  - Vuetify directives with prefix support similar to previous described at `unimport` presets: won't work since `unplugin-vue-components` doesn't augment the vue module properly (iirc there is a PR to fix it)

Here  some GH repos using Vuetify (dev) PR:
- https://github.com/userquin/vuetify-nuxt-3.16-lazy-hydration/pull/3
- https://github.com/userquin/check-vuetify-unplugin-vue-components-2
- https://github.com/userquin/vuetify-nuxt-unimport-component-prefix/tree/main (using prefix for components, directives and composables with some example using Nuxt Vue Lazy Hydration with VBtn and VCalendar in an SSR app with dark/light themes and http client hints)
- https://github.com/userquin/vuetify-nuxt-unimport-component-prefix/tree/use-unplugin-vuetify using this PR instead Vuetify, check https://github.com/userquin/vuetify-nuxt-unimport-component-prefix/pull/1 PR

<details>
<summary>We need to replace keys in the existing <strong>transformAssetUrls</strong> entries</summary>

![image](https://github.com/user-attachments/assets/da56d358-2d2f-422c-ad7d-46060d74d6e0)
_current transformAssetUrls map, won't work when using Vuetify component prefix_
</details>