### PR TITLE
fix: account for spaces when extracting components and directives

### DIFF
--- a/packages/shared/src/imports/parseTemplate.ts
+++ b/packages/shared/src/imports/parseTemplate.ts
@@ -1,8 +1,8 @@
 import { camelize, capitalize } from 'vue'
 
 export function parseTemplate (source: string) {
-  const components = createSet(source.matchAll(/(?:var|const) (\w+) ?= ?_resolveComponent\("([\w-.]+)"\);?/gm))
-  const directives = createSet(source.matchAll(/(?:var|const) (\w+) ?= ?_resolveDirective\("([\w-.]+)"\);?/gm))
+  const components = createSet(source.matchAll(/(?:var|const) (\w+) *?= *?_resolveComponent\("([\w-.]+)"\);?/gm))
+  const directives = createSet(source.matchAll(/(?:var|const) (\w+) *?= *?_resolveDirective\("([\w-.]+)"\);?/gm))
 
   return { components, directives }
 }

--- a/packages/shared/src/imports/parseTemplate.ts
+++ b/packages/shared/src/imports/parseTemplate.ts
@@ -1,8 +1,8 @@
 import { camelize, capitalize } from 'vue'
 
 export function parseTemplate (source: string) {
-  const components = createSet(source.matchAll(/(?:var|const) (\w+) = _resolveComponent\("([\w-.]+)"\);?/gm))
-  const directives = createSet(source.matchAll(/(?:var|const) (\w+) = _resolveDirective\("([\w-.]+)"\);?/gm))
+  const components = createSet(source.matchAll(/(?:var|const) (\w+) ?= ?_resolveComponent\("([\w-.]+)"\);?/gm))
+  const directives = createSet(source.matchAll(/(?:var|const) (\w+) ?= ?_resolveDirective\("([\w-.]+)"\);?/gm))
 
   return { components, directives }
 }


### PR DESCRIPTION
The current pattern assumes that compiled code will have spaces before and after the `=` character even though that isn't a requirement of the language for assignments, so it won't work if a build pipeline omits either of those spaces (which is what is happening in one of our applications).

This updated pattern matches any number of spaces on either side of the `=` character, including zero